### PR TITLE
Fix for two scrollers in one parentScroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.0.12
+
+* Fix the bug, when parentScroll is significantly longer, then virtual scroller.
+
 # v1.0.11
 
 * Fix issue #258

--- a/src/virtual-scroller.ts
+++ b/src/virtual-scroller.ts
@@ -1204,7 +1204,7 @@ export class VirtualScrollerComponent implements OnInit, OnChanges, OnDestroy {
 		let offset = this.getElementsOffset();
 
 		let scrollStartPosition = this.getScrollStartPosition();
-		if (scrollStartPosition > dimensions.scrollLength && !(this.parentScroll instanceof Window)) {
+		if (scrollStartPosition > (dimensions.scrollLength + offset) && !(this.parentScroll instanceof Window)) {
 			scrollStartPosition = dimensions.scrollLength;
 		} else {
 			scrollStartPosition -= offset;


### PR DESCRIPTION
If there are two or more scrollers (or one scroller after a very huge block before it (with the size of all virtual scroll items)) in one parent then it was not working. This small fix is fixing that