### PR TITLE
Use "bufferAmount" manual value if specified.

### DIFF
--- a/src/virtual-scroller.ts
+++ b/src/virtual-scroller.ts
@@ -209,7 +209,11 @@ export class VirtualScrollerComponent implements OnInit, OnChanges, OnDestroy {
 	protected _bufferAmount: number = 0;
 	@Input()
 	public get bufferAmount(): number {
-		return Math.max(this._bufferAmount, this.enableUnequalChildrenSizes ? 5 : 0);
+		if (typeof (this._bufferAmount) === 'number' && this._bufferAmount > 0) {
+			return this._bufferAmount;
+		} else {
+			return this.enableUnequalChildrenSizes ? 5 : 0;	
+		}
 	}
 	public set bufferAmount(value: number) {
 		this._bufferAmount = value;


### PR DESCRIPTION
Hi thanks for great library.

I'm using with ionic framework. 
I have a performance problem on Android device.

I've tried options tuning.
Finallly found solution for me.

It is `bufferAmount` value tuning.
If the value is small, It's good for me.

So, I want to set the value intented. Even if using `enableUnequalChildrenSizes` option.

Thanks.