### PR TITLE
Fixed nativeElement of undefined in Angular 8

### DIFF
--- a/src/virtual-scroller.ts
+++ b/src/virtual-scroller.ts
@@ -110,7 +110,7 @@ export interface IViewport extends IPageInfo {
 	  display: block;
       -webkit-overflow-scrolling: touch;
     }
-	
+
 	:host.horizontal.selfScroll {
       overflow-y: visible;
       overflow-x: auto;
@@ -119,7 +119,7 @@ export interface IViewport extends IPageInfo {
       overflow-y: auto;
       overflow-x: visible;
 	}
-	
+
     .scrollable-content {
       top: 0;
       left: 0;
@@ -133,26 +133,26 @@ export interface IViewport extends IPageInfo {
 	.scrollable-content ::ng-deep > * {
 		box-sizing: border-box;
 	}
-	
+
 	:host.horizontal {
 		white-space: nowrap;
 	}
-	
+
 	:host.horizontal .scrollable-content {
 		display: flex;
 	}
-	
+
 	:host.horizontal .scrollable-content ::ng-deep > * {
 		flex-shrink: 0;
 		flex-grow: 0;
 		white-space: initial;
 	}
-	
+
     .total-padding {
       width: 1px;
       opacity: 0;
     }
-    
+
     :host.horizontal .total-padding {
       height: 100%;
     }
@@ -232,7 +232,7 @@ export class VirtualScrollerComponent implements OnInit, OnChanges, OnDestroy {
 		if (typeof (this._bufferAmount) === 'number' && this._bufferAmount >= 0) {
 			return this._bufferAmount;
 		} else {
-			return this.enableUnequalChildrenSizes ? 5 : 0;	
+			return this.enableUnequalChildrenSizes ? 5 : 0;
 		}
 	}
 	public set bufferAmount(value: number) {
@@ -371,10 +371,10 @@ export class VirtualScrollerComponent implements OnInit, OnChanges, OnDestroy {
 	@Output()
 	public vsEnd: EventEmitter<IPageInfo> = new EventEmitter<IPageInfo>();
 
-	@ViewChild('content', { read: ElementRef, static: false })
+	@ViewChild('content', { read: ElementRef, static: true })
 	protected contentElementRef: ElementRef;
 
-	@ViewChild('invisiblePadding', { read: ElementRef, static: false })
+	@ViewChild('invisiblePadding', { read: ElementRef, static: true })
 	protected invisiblePaddingElementRef: ElementRef;
 
 	@ContentChild('header', { read: ElementRef, static: false })
@@ -400,14 +400,14 @@ export class VirtualScrollerComponent implements OnInit, OnChanges, OnDestroy {
 		this.refresh_internal(indexLengthChanged || firstRun);
 	}
 
-	
+
 	public ngDoCheck(): void {
 		if (this.cachedItemsLength !== this.items.length) {
 			this.cachedItemsLength = this.items.length;
 			this.refresh_internal(true);
 			return;
 		}
-		
+
 		if (this.previousViewPort && this.viewPortItems && this.viewPortItems.length > 0) {
 			let itemsArrayChanged = false;
 			for (let i = 0; i < this.viewPortItems.length; ++i) {
@@ -585,7 +585,7 @@ export class VirtualScrollerComponent implements OnInit, OnChanges, OnDestroy {
 		@Inject(PLATFORM_ID) platformId: Object,
 		@Optional() @Inject('virtual-scroller-default-options')
 		options: VirtualScrollerDefaultOptions) {
-			
+
 		this.isAngularUniversalSSR = isPlatformServer(platformId);
 
 		this.scrollThrottlingTime = options.scrollThrottlingTime;
@@ -601,7 +601,7 @@ export class VirtualScrollerComponent implements OnInit, OnChanges, OnDestroy {
 		this.horizontal = false;
 		this.resetWrapGroupDimensions();
 	}
-	
+
 	protected getElementSize(element: HTMLElement) : ClientRect {
 		let result = element.getBoundingClientRect();
 		let styles = getComputedStyle(element);
@@ -609,7 +609,7 @@ export class VirtualScrollerComponent implements OnInit, OnChanges, OnDestroy {
 		let marginBottom = parseInt(styles['margin-bottom'], 10) || 0;
 		let marginLeft = parseInt(styles['margin-left'], 10) || 0;
 		let marginRight = parseInt(styles['margin-right'], 10) || 0;
-		
+
 		return {
 			top: result.top + marginTop,
 			bottom: result.bottom + marginBottom,
@@ -733,7 +733,7 @@ export class VirtualScrollerComponent implements OnInit, OnChanges, OnDestroy {
 		//if items were prepended, scroll forward to keep same items visible
 			let oldViewPort = this.previousViewPort;
 			let oldViewPortItems = this.viewPortItems;
-			
+
 			let oldRefreshCompletedCallback = refreshCompletedCallback;
 			refreshCompletedCallback = () => {
 				let scrollLengthDelta = this.previousViewPort.scrollLength - oldViewPort.scrollLength;
@@ -748,19 +748,19 @@ export class VirtualScrollerComponent implements OnInit, OnChanges, OnDestroy {
 								break;
 							}
 						}
-						
+
 						if (!itemOrderChanged) {
 							this.scrollToPosition(this.previousViewPort.scrollStartPosition + scrollLengthDelta , 0, oldRefreshCompletedCallback);
 							return;
 						}
 					}
 				}
-				
+
 				if (oldRefreshCompletedCallback) {
 					oldRefreshCompletedCallback();
 				}
 			};
-		}			
+		}
 
 		this.zone.runOutsideAngular(() => {
 			requestAnimationFrame(() => {


### PR DESCRIPTION
In Angular 8 ViewChild requires setting attribute "static". If element can be resolved at compile time, static should be true. 

`@ViewChild('content', { read: ElementRef, static: false })` cause error on component loading.