### PR TITLE
Fix default buffer amount

### DIFF
--- a/src/virtual-scroller.ts
+++ b/src/virtual-scroller.ts
@@ -226,7 +226,7 @@ export class VirtualScrollerComponent implements OnInit, OnChanges, OnDestroy {
 	@Input()
 	public ssrViewportHeight: number = 1080;
 
-	protected _bufferAmount: number = 0;
+	protected _bufferAmount: number;
 	@Input()
 	public get bufferAmount(): number {
 		if (typeof (this._bufferAmount) === 'number' && this._bufferAmount >= 0) {


### PR DESCRIPTION
Buffer amount should be 5 by default when unequal children sizes are
enabled. But it was initialized at zero and stayed at zero: the check
for children sizes only fires for non-numeric buffer amounts.

We had a problem: scroll was very jerky. Turned out it had zero buffer
amount, we worked around by specifying it manually. At the moment this
behavior contradicts the readme.