### PR TITLE
alphabetize, indent, clarify

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,7 +382,9 @@ import { VirtualScrollerComponent } from 'ngx-virtual-scroller';
     selector: 'rj-list',
     template: `
         <virtual-scroller #scroll [items]="items">
-            <div *ngFor="let item of scroll.viewPortItems; let i = index"> {{i}}: {{item}} </div>
+            <div *ngFor="let item of scroll.viewPortItems; let i = index">
+                {{i}}: {{item}}
+            </div>
         </virtual-scroller>
     `
 })
@@ -414,7 +416,9 @@ import { VirtualScrollerComponent } from 'ngx-virtual-scroller';
     selector: 'rj-list',
     template: `
         <virtual-scroller #scroll [items]="items">
-            <div *ngFor="let item of scroll.viewPortItems; let i = index"> {{i}}: {{item}} </div>
+            <div *ngFor="let item of scroll.viewPortItems; let i = index">
+                {{i}}: {{item}}
+            </div>
         </virtual-scroller>
     `
 })
@@ -524,8 +528,10 @@ Here's an example of how to do this:
 
 ```html
 <virtual-scroller #scroll [items]="myComplexItems">
-	<my-custom-component [myComplexItem]="complexItem" *ngFor="let complexItem of scroll.viewPortItems; trackBy: myTrackByFunction">
-	</my-custom-component>
+    <my-custom-component
+        [myComplexItem]="complexItem"
+        *ngFor="let complexItem of scroll.viewPortItems; trackBy: myTrackByFunction">
+    </my-custom-component>
 </virtual-scroller>
 ```
 
@@ -669,13 +675,17 @@ In this case you can get a free/easy performance boost with the following code:
 import { ChangeDetectorRef } from '@angular/core';
 
 public class MainComponent {
-	constructor(public changeDetectorRef: ChangeDetectorRef) {
-	}
+    constructor(public changeDetectorRef: ChangeDetectorRef) { }
 }
 ```
 
 ```html
-<virtual-scroller #scroll [items]="items" [executeRefreshOutsideAngularZone]="true" (vsUpdate)="changeDetectorRef.detectChanges()">
+<virtual-scroller
+    #scroll
+    [items]="items"
+    [executeRefreshOutsideAngularZone]="true"
+    (vsUpdate)="changeDetectorRef.detectChanges()"
+>
     <my-custom-component *ngFor="let item of scroll.viewPortItems">
     </my-custom-component>
 </virtual-scroller>

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ import { VirtualScrollerModule } from 'ngx-virtual-scroller';
 export class AppModule { }
 ```
 
-**Step 3:** Wrap virtual-scroller tag around elements;
+**Step 3:** Wrap _virtual-scroller_ tag around elements;
 
 ```ts
 <virtual-scroller #scroll [items]="items">
@@ -171,7 +171,7 @@ In _alphabetical_ order:
 | Attribute                          | `Type` & Default  | Description
 |------------------------------------|-------------------|--------------|
 | bufferAmount                       | `number` enableUnequalChildrenSizes ? 5 : 0 | The number of elements to be rendered above & below the current container's viewport. Increase this if `enableUnequalChildrenSizes` isn't working well enough.
-| checkResizeInterval                | `number` 1000     | How often in milliseconds to check if virtual-scroller (or parentScroll) has been resized. If resized, it'll call `Refresh()` method
+| checkResizeInterval                | `number` 1000     | How often in milliseconds to check if _virtual-scroller_ (or parentScroll) has been resized. If resized, it'll call `Refresh()` method
 | compareItems                       | `Function` === comparison | Predicate of syntax `(item1:any, item2:any)=>boolean` which is used when items array is modified to determine which items have been changed (determines if cached child size measurements need to be refreshed or not for `enableUnequalChildrenSizes`).
 | enableUnequalChildrenSizes         | `boolean` false   | If you want to use the "unequal size" children feature. This is not perfect, but hopefully "close-enough" for most situations.
 | executeRefreshOutsideAngularZone   | `boolean` false   | Disables full-app Angular ChangeDetection while scrolling, which can give a performance boost. Requires developer to manually execute change detection on any components which may have changed. USE WITH CAUTION - Read the "Performance" section below.
@@ -184,7 +184,7 @@ In _alphabetical_ order:
 | parentScroll                       | Element / Window  | Element (or window), which will have scrollbar. This element must be one of the parents of virtual-scroller
 | refresh                            | `Function`        | `()=>void` - to force re-rendering of current items in viewport.
 | RTL                                | `boolean` false   | Set to `true` if you want horizontal slider to support right to left script (RTL).
-| resizeBypassRefreshThreshold       | `number` 5        | How many pixels to ignore during resize check if virtual-scroller (or parentScroll) are only resized by a very small amount.
+| resizeBypassRefreshThreshold       | `number` 5        | How many pixels to ignore during resize check if _virtual-scroller_ (or parentScroll) are only resized by a very small amount.
 | scrollAnimationTime                | `number` 750      | The time in milliseconds for the scroll animation to run for. 0 will completely disable the tween/animation.
 | scrollDebounceTime                 | `number` 0        | Milliseconds to delay refreshing viewport if user is scrolling quickly (for performance reasons).
 | scrollInto                         | `Function`        | `(item:any, alignToBeginning:boolean = true, additionalOffset:number = 0, animationMilliseconds:number = undefined, animationCompletedCallback:()=>void = undefined)=>void` - Scrolls to item
@@ -195,8 +195,8 @@ In _alphabetical_ order:
 | scrollbarWidth                     | `number`          | If you want to override the auto-calculated scrollbar width. This is used to determine the dimensions of the viewable area when calculating the number of items to render.
 | ssrChildHeight                     | `number`          | The hard-coded height of the item template's cell to use if rendering via _Angular Universal/Server-Side-Rendering_
 | ssrChildWidth                      | `number`          | The hard-coded width of the item template's cell to use if rendering via _Angular Universal/Server-Side-Rendering_
-| ssrViewportHeight                  | `number` 1080     | The hard-coded visible height of the virtual-scroller (or [parentScroll]) to use if rendering via _Angular Universal/Server-Side-Rendering_.
-| ssrViewportWidth                   | `number` 1920     | The hard-coded visible width of the virtual-scroller (or [parentScroll]) to use if rendering via _Angular Universal/Server-Side-Rendering_.
+| ssrViewportHeight                  | `number` 1080     | The hard-coded visible height of the _virtual-scroller_ (or [parentScroll]) to use if rendering via _Angular Universal/Server-Side-Rendering_.
+| ssrViewportWidth                   | `number` 1920     | The hard-coded visible width of the _virtual-scroller_ (or [parentScroll]) to use if rendering via _Angular Universal/Server-Side-Rendering_.
 | stripedTable                       | `boolean` false   | Set to true if you use a striped table. In this case, the rows will be added/removed two by two to keep the strips consistent.
 | useMarginInsteadOfTranslate        | `boolean` false   | Translate is faster in many scenarios because it can use GPU acceleration, but it can be slower if your scroll container or child elements don't use any transitions or opacity. More importantly, translate creates a new "containing block" which breaks position:fixed because it'll be relative to the transform rather than the window. If you're experiencing issues with position:fixed on your child elements, turn this flag on.
 | viewPortInfo                       | `IPageInfo`       | Allows querying the the current viewport info on demand rather than listening for events.
@@ -210,7 +210,7 @@ In _alphabetical_ order:
 
 *Note* - The Events without the "vs" prefix have been deprecated because they might conflict with native DOM events due to their "bubbling" nature. See https://github.com/angular/angular/issues/13997
 
-An example is if an `<input>` element inside `<virtual-scroller>` emits a "change" event which bubbles up to the (change) handler of virtual-scroller. Using the vs prefix will prevent this bubbling conflict because there are currently no official DOM events prefixed with vs.
+An example is if an `<input>` element inside `<virtual-scroller>` emits a "change" event which bubbles up to the (change) handler of _virtual-scroller_. Using the vs prefix will prevent this bubbling conflict because there are currently no official DOM events prefixed with vs.
 
 ## Use parent scrollbar
 
@@ -228,7 +228,7 @@ If you want to use the scrollbar of a parent element, set `parentScroll` to a na
 </div>
 ```
 
-If the parentScroll is a custom angular component (instead of a native HTML element such as DIV), Angular will wrap the #scrollingBlock variable in an ElementRef https://angular.io/api/core/ElementRef in which case you'll need to use the .nativeElement property to get to the underlying javascript DOM element reference.
+If the parentScroll is a custom angular component (instead of a native HTML element such as DIV), Angular will wrap the `#scrollingBlock` variable in an ElementRef https://angular.io/api/core/ElementRef in which case you'll need to use the `.nativeElement` property to get to the underlying JavasSript DOM element reference.
 
 ```html
 <custom-angular-component #scrollingBlock>
@@ -260,9 +260,9 @@ If you want to use the window's scrollbar, set `parentScroll`.
 
 ## Items with variable size
 
-Items must have fixed height and width for this module to work perfectly. If not, set [enableUnequalChildrenSizes]="true".
+Items _must_ have fixed height and width for this module to work perfectly. If not, set `[enableUnequalChildrenSizes]="true"`.
 
-*(DEPRECATED)*: If enableUnequalChildrenSizes isn't working, you can set inputs `childWidth` and `childHeight` to their smallest possible values. You can also modify `bufferAmount` which causes extra items to be rendered on the edges of the scrolling area.
+*(DEPRECATED)*: If `enableUnequalChildrenSizes` isn't working, you can set inputs `childWidth` and `childHeight` to their smallest possible values. You can also modify `bufferAmount` which causes extra items to be rendered on the edges of the scrolling area.
 
 ```html
 <virtual-scroller #scroll [items]="items" [enableUnequalChildrenSizes]="true">
@@ -317,7 +317,7 @@ export class ListWithApiComponent implements OnChanges {
 
 ## With HTML Table
 
-*Note* - The #header angular selector will make the `<thead>` element fixed to top. If you want the header to scroll out of view don't add the _#header_ angular element ref.
+*Note* - The `#header` angular selector will make the `<thead>` element fixed to top. If you want the header to scroll out of view don't add the `#header` angular element ref.
 
 ```html
 <virtual-scroller #scroll [items]="myItems">
@@ -343,8 +343,9 @@ export class ListWithApiComponent implements OnChanges {
 ```
 
 ## If child size changes
-virtual-scroller caches the measurements for the rendered items. If enableUnequalChildrenSizes===true then each item is measured and cached separately. Otherwise, the 1st measured item is used for all items.
-If your items can change sizes dynamically, you'll need to notify virtual-scroller to re-measure them. There are 3 methods for doing this:
+virtual-scroller caches the measurements for the rendered items. If `enableUnequalChildrenSizes===true` then each item is measured and cached separately. Otherwise, the 1st measured item is used for all items.
+
+If your items can change sizes dynamically, you'll need to notify _virtual-scroller_ to re-measure them. There are 3 methods for doing this:
 ```ts
 virtualScroller.invalidateAllCachedMeasurements();
 virtualScroller.invalidateCachedMeasurementForItem(item: any);
@@ -371,10 +372,13 @@ Example:
 ## If container size changes
 
 *Note* - This should now be auto-detected, however the 'refresh' method can still force it if neeeded.
-    This was implemented using the setInterval method which may cause minor performance issues. It shouldn't be noticeable, but can be disabled via `[checkResizeInterval]="0"`
-    Performance will be improved once "Resize Observer" (https://wicg.github.io/ResizeObserver/) is fully implemented.
+
+This was implemented using the setInterval method which may cause minor performance issues. It shouldn't be noticeable, but can be disabled via `[checkResizeInterval]="0"`
+
+Performance will be improved once "Resize Observer" (https://wicg.github.io/ResizeObserver/) is fully implemented.
 
 Refresh method *(DEPRECATED)*
+
 If virtual scroll is used within a dropdown or collapsible menu, virtual scroll needs to know when the container size changes. Use `refresh()` function after container is resized (include time for animation as well).
 
 ```ts
@@ -407,9 +411,7 @@ export class ListComponent {
 
 ## Focus an item
 
-You can use the `scrollInto(item, alignToBeginning?, additionalOffset?, animationMilliseconds?, animationCompletedCallback?)` api to scroll into an item in the list.
-You can also use the `scrollToIndex(index, alignToBeginning?, additionalOffset?, animationMilliseconds?, animationCompletedCallback?)` api for the same purpose.
-See below:
+You can use the `scrollInto()` or `scrollToIndex()` API to scroll into an item in the list:
 
 ```ts
 import { Component, ViewChild } from '@angular/core';
@@ -442,7 +444,7 @@ export class ListComponent {
 
 ## Dependency Injection of configuration settings
 
-Some default config settings can be overridden via DI, so you can set them globally instead of on each instance of virtual-scroller.
+Some default config settings can be overridden via DI, so you can set them globally instead of on each instance of _virtual-scroller_.
 
 ```ts
 providers: [
@@ -503,7 +505,7 @@ This hacky CSS allows hiding a scrollbar while still enabling scroll through mou
 
 ## Additional elements in scroll
 
-If you want to nest additional elements inside virtual scroll besides the list itself (e.g. search field), you need to wrap those elements in a tag with an angular selector name of #container.
+If you want to nest additional elements inside virtual scroll besides the list itself (e.g. search field), you need to wrap those elements in a tag with an angular selector name of `#container`.
 
 ```html
 <virtual-scroller #scroll [items]="items">
@@ -517,15 +519,15 @@ If you want to nest additional elements inside virtual scroll besides the list i
 
 ## Performance - TrackBy
 
-virtual-scroller uses *ngFor to render the visible items. When an *ngFor array changes, Angular uses a trackBy function to determine if it should re-use or re-generate each component in the loop.
+virtual-scroller uses `*ngFor` to render the visible items. When an `*ngFor` array changes, Angular uses a _trackBy_ function to determine if it should re-use or re-generate each component in the loop.
 
 For example, if 5 items are visible and scrolling causes 1 item to swap out but the other 4 remain visible, there's no reason Angular should re-generate those 4 components from scratch, it should reuse them.
 
 A trackBy function must return either a number or string as a unique identifier for your object.
 
-If the array used by *ngFor is of type `number[]` or `string[]`, Angular's default trackBy function will work automatically, you don't need to do anything extra.
+If the array used by `*ngFor` is of type `number[]` or `string[]`, Angular's default trackBy function will work automatically, you don't need to do anything extra.
 
-If the array used by *ngFor is of type `any[]`, you must code your own trackBy function.
+If the array used by `*ngFor` is of type `any[]`, you must code your own trackBy function.
 
 Here's an example of how to do this:
 
@@ -540,36 +542,36 @@ Here's an example of how to do this:
 
 ```ts
 public interface IComplexItem {
-	uniqueIdentifier: number;
-	extraData: any;
+    uniqueIdentifier: number;
+    extraData: any;
 }
 
 public myTrackByFunction(index: number, complexItem: IComplexItem): number {
-	return complexItem.uniqueIdentifier;
+    return complexItem.uniqueIdentifier;
 }
 ```
 
 ## Performance - ChangeDetection
 
-_virtual-scroller_ is coded to be extremely fast. If scrolling is slow in your app, the issue is with your custom component code, not with virtual-scroller itself.
-Below is an explanation of how to correct your code. This will make your entire app much faster, including virtual-scroller.
+_virtual-scroller_ is coded to be extremely fast. If scrolling is slow in your app, the issue is with your custom component code, not with _virtual-scroller_ itself.
+Below is an explanation of how to correct your code. This will make your entire app much faster, including _virtual-scroller_.
 
 Each component in Angular by default uses the `ChangeDetectionStrategy.Default` "CheckAlways" strategy. This means that Change Detection cycles will be running constantly which will check *EVERY* data-binding expression on *EVERY* component to see if anything has changed.
 This makes it easier for programmers to code apps, but also makes apps extremely slow.
 
-If virtual-scroller feels slow, a possible quick solution that masks the real problem is to use `scrollThrottlingTime` or `scrollDebounceTime` APIs.
+If _virtual-scroller_ feels slow, a possible quick solution that masks the real problem is to use `scrollThrottlingTime` or `scrollDebounceTime` APIs.
 
 The correct fix is to make cycles as fast as possible and to avoid unnecessary ChangeDetection cycles. Cycles will be faster if you avoid complex logic in data-bindings. You can avoid unnecessary Cycles by converting your components to use `ChangeDetectionStrategy.OnPush`.
 
-ChangeDetectionStrategy.OnPush means the consuming app is taking full responsibility for telling Angular when to run change detection rather than allowing Angular to figure it out itself. For example, virtual-scroller has a bound property `[items]="myItems"`. If you use OnPush, you have to tell Angular when you change the myItems array, because it won't determine this automatically.
+ChangeDetectionStrategy.OnPush means the consuming app is taking full responsibility for telling Angular when to run change detection rather than allowing Angular to figure it out itself. For example, _virtual-scroller_ has a bound property `[items]="myItems"`. If you use OnPush, you have to tell Angular when you change the myItems array, because it won't determine this automatically.
 OnPush is much harder for the programmer to code. You have to code things differently: This means
 1) avoid mutating state on any bound properties where possible &
 2) manually running change detection when you do mutate state.
 OnPush can be done on a component-by-component basis, however I recommend doing it for *EVERY* component in your app.
 
-If your biggest priority is making virtual-scroller faster, the best candidates for _OnPush_ will be all custom components being used as children underneath virtual-scroller. If you have a hierarchy of multiple custom components under virtual-scroller, ALL of them need to be converted to _OnPush_.
+If your biggest priority is making _virtual-scroller_ faster, the best candidates for _OnPush_ will be all custom components being used as children underneath _virtual-scroller_. If you have a hierarchy of multiple custom components under virtual-scroller, ALL of them need to be converted to _OnPush_.
 
-My personal suggestion on the easiest way to implement OnPush across your entire app:
+My personal suggestion on the easiest way to implement _OnPush_ across your entire app:
 ```ts
 import { ChangeDetectorRef } from '@angular/core';
 
@@ -663,15 +665,15 @@ public class SomeRandomComponentWhichUsesOnPush {
     }
 }
 ```
-The ManualChangeDetection/Util classes are helpers that can be copy/pasted directly into your app. The code for MyEntryLevelAppComponent & SomeRandomComponentWhichUsesOnPush are examples that you'll need to modify for your specific app. If you follow this pattern, OnPush is much easier to implement. However, the really hard part is analyzing all of your code to determine *where* you're mutating state. Unfortunately there's no magic bullet for this, you'll need to spend a lot of time reading/debugging/testing your code.
+The ManualChangeDetection/Util classes are helpers that can be copy/pasted directly into your app. The code for MyEntryLevelAppComponent & SomeRandomComponentWhichUsesOnPush are examples that you'll need to modify for your specific app. If you follow this pattern, _OnPush_ is much easier to implement. However, the really hard part is analyzing all of your code to determine *where* you're mutating state. Unfortunately there's no magic bullet for this, you'll need to spend a lot of time reading/debugging/testing your code.
 
 ## Performance - executeRefreshOutsideAngularZone
 
 This API is meant as a quick band-aid fix for performance issues. Please read the other performance sections above to learn the ideal way to fix performance issues.
 
-`ChangeDetectionStrategy.OnPush` is the recommended strategy as it improves the entire app performance, not just virtual-scroller. However, `ChangeDetectionStrategy.OnPush` is hard to implement. executeRefreshOutsideAngularZone may be an easier initial approach until you're ready to tackle `ChangeDetectionStrategy.OnPush`.
+`ChangeDetectionStrategy.OnPush` is the recommended strategy as it improves the entire app performance, not just _virtual-scroller_. However, `ChangeDetectionStrategy.OnPush` is hard to implement. `executeRefreshOutsideAngularZone` may be an easier initial approach until you're ready to tackle `ChangeDetectionStrategy.OnPush`.
 
-If you've correctly implemented ChangeDetectionStrategy.OnPush for 100% of your components, the executeRefreshOutsideAngularZone will not provide any performance benefit.
+If you've correctly implemented `ChangeDetectionStrategy.OnPush` for 100% of your components, the `executeRefreshOutsideAngularZone` will not provide any performance benefit.
 If you have not yet done this, scrolling may feel slow. This is because Angular performs a full-app change detection while scrolling. However, it's likely that only the components inside the scroller actually need the change detection to run, so a full-app change detection cycle is overkill.
 In this case you can get a free/easy performance boost with the following code:
 ```ts
@@ -694,34 +696,34 @@ public class MainComponent {
 </virtual-scroller>
 ```
 
-*Note* - `executeRefreshOutsideAngularZone` will disable Angular ChangeDetection during all virtual-scroller events, including: vsUpdate, vsStart, vsEnd, vsChange. If you change any data-bound properties inside these event handlers, you must perform manual change detection on those specific components. This can be done via `changeDetectorRef.detectChanges()` at the end of the event handler.
+*Note* - `executeRefreshOutsideAngularZone` will disable Angular ChangeDetection during all _virtual-scroller_ events, including: vsUpdate, vsStart, vsEnd, vsChange. If you change any data-bound properties inside these event handlers, you must perform manual change detection on those specific components. This can be done via `changeDetectorRef.detectChanges()` at the end of the event handler.
 
-*Note* - The `changeDetectorRef` is component-specific, so you'll need to inject it into a private variable in the constructor of the appropriate component before calling it in response to the virtual-scroller events.
+*Note* - The `changeDetectorRef` is component-specific, so you'll need to inject it into a private variable in the constructor of the appropriate component before calling it in response to the _virtual-scroller_ events.
 
 :warning: *WARNING* - Failure to perform manual change detection in response to _virtual-scroller_ events will cause your components to render a stale UI for a short time (until the next Change Detection cycle), which will make your app feel buggy.
 
-*Note* - `changeDetectorRef.detectChanges()` will execute change detection on the component and all its nested children. If multiple components need to run change detection in response to a virtual-scroller event, you can call detectChanges from a higher-level component in the ancestor hierarchy rather than on each individual component. However, its important to avoid too many extra change detection cycles by not going too high in the hierarchy unless all the nested children really need to have change detection performed.
+*Note* - `changeDetectorRef.detectChanges()` will execute change detection on the component and all its nested children. If multiple components need to run change detection in response to a _virtual-scroller_ event, you can call detectChanges from a higher-level component in the ancestor hierarchy rather than on each individual component. However, its important to avoid too many extra change detection cycles by not going too high in the hierarchy unless all the nested children really need to have change detection performed.
 
-*Note* - All virtual-scroller events are emitted at the same time in response to its internal "refresh" function. Some of these event emitters are bypassed if certain criteria don't apply. however vsUpdate will always be emitted. For this reason, you should consolidate all data-bound property changes & manual change detection into the vsUpdate event handler, to avoid duplicate change detection cycles from executing during the other virtual-scroller events.
+*Note* - All _virtual-scroller_ events are emitted at the same time in response to its internal "refresh" function. Some of these event emitters are bypassed if certain criteria don't apply. however vsUpdate will always be emitted. For this reason, you should consolidate all data-bound property changes & manual change detection into the vsUpdate event handler, to avoid duplicate change detection cycles from executing during the other _virtual-scroller_ events.
 
-In the above code example, `(vsUpdate)="changeDetectorRef.detectChanges()"` is necessary because `scroll.viewPortItems` was changed internally be virtual-scroller during its internal "render" function before emitting (vsUpdate). `executeRefreshOutsideAngularZone` prevents _MainComponent_ from refreshing its data-binding in response to this change, so a manual Change Detection cycle must be run. No extra manual change detection code is necessary for virtual-scroller or my-custom-component, even if their data-bound properties have changed, because they're nested children of _MainComponent_.
+In the above code example, `(vsUpdate)="changeDetectorRef.detectChanges()"` is necessary because `scroll.viewPortItems` was changed internally be _virtual-scroller_ during its internal "render" function before emitting (vsUpdate). `executeRefreshOutsideAngularZone` prevents _MainComponent_ from refreshing its data-binding in response to this change, so a manual Change Detection cycle must be run. No extra manual change detection code is necessary for _virtual-scroller_ or my-custom-component, even if their data-bound properties have changed, because they're nested children of _MainComponent_.
 
 ## Performance - scrollDebounceTime / scrollThrottlingTime
 
 These APIs are meant as a quick band-aid fix for performance issues. Please read the other performance sections above to learn the ideal way to fix performance issues.
 
-Without these set, virtual-scroller will refresh immediately whenever the user scrolls.
+Without these set, _virtual-scroller_ will refresh immediately whenever the user scrolls.
 Throttle will delay refreshing until _# milliseconds_ after scroll started. As the user continues to scroll, it will wait the same _# milliseconds_ in between each successive refresh. Even if the user stops scrolling, it will still wait the allocated time before the final refresh.
 Debounce won't refresh until the user has stopped scrolling for _# milliseconds_.
 If both Debounce & Throttling are set, debounce takes precedence.
 
-*Note* - If virtual-scroller hasn't refreshed & the user has scrolled past bufferAmount, no child items will be rendered and virtual-scroller will appear blank. This may feel confusing to the user. You may want to have a spinner or loading message display when this occurs.
+*Note* - If _virtual-scroller_ hasn't refreshed & the user has scrolled past bufferAmount, no child items will be rendered and _virtual-scroller_ will appear blank. This may feel confusing to the user. You may want to have a spinner or loading message display when this occurs.
 
 ## Angular Universal / Server-Side Rendering
 
-The initial SSR render isn't a fully functioning site, it's essentially an HTML "screenshot" (HTML/CSS, but no JS). However, it immediately swaps out your "screenshot" with the real site as soon as the full app has downloaded in the background. The intent of SSR is to give a correct visual very quickly, because a full angular app could take a long time to download. This makes the user *think* your site is fast, because hopefully they won't click on anything that requires JS before the fully-functioning site has finished loading in the background. Also, it allows screen scrapers without javascript to work correctly (example: Facebook posts/etc).
+The initial SSR render isn't a fully functioning site, it's essentially an HTML "screenshot" (HTML/CSS, but no JS). However, it immediately swaps out your "screenshot" with the real site as soon as the full app has downloaded in the background. The intent of SSR is to give a correct visual very quickly, because a full angular app could take a long time to download. This makes the user *think* your site is fast, because hopefully they won't click on anything that requires JS before the fully-functioning site has finished loading in the background. Also, it allows screen scrapers without JavasSript to work correctly (example: Facebook posts/etc).
 
-virtual-scroller relies on javascript APIs to measure the size of child elements and the scrollable area of their parent. These APIs do not work in SSR because the HTML/CSS "screenshot" is generated on the server via Node, it doesn't execute/render the site as a browser would. This means virtual-scroller will see all measurements as undefined and the "screenshot" will not be generated correctly. Most likely, only 1 child element will appear in your virtual-scroller. This "screenshot" can be fixed with polyfills. However, when the browser renders the "screenshot", the scrolling behaviour still won't work until the full app has loaded.
+virtual-scroller relies on JavasSript APIs to measure the size of child elements and the scrollable area of their parent. These APIs do not work in SSR because the HTML/CSS "screenshot" is generated on the server via Node, it doesn't execute/render the site as a browser would. This means _virtual-scroller_ will see all measurements as undefined and the "screenshot" will not be generated correctly. Most likely, only 1 child element will appear in your _virtual-scroller_. This "screenshot" can be fixed with polyfills. However, when the browser renders the "screenshot", the scrolling behaviour still won't work until the full app has loaded.
 
 SSR is an advanced (and complex) topic that can't be fully addressed here. Please research this on your own. However, here are some suggestions:
 1) Use https://www.npmjs.com/package/domino and https://www.npmjs.com/package/raf polyfills in your main.server.ts file
@@ -735,7 +737,7 @@ global['document'] = win.document;
 Object.defineProperty(win.document.body.style, 'transform', { value: () => { return { enumerable: true, configurable: true }; } });
 ```
 2) Determine a default screen size you want to use for the SSR "screenshot" calculations (suggestion: 1920x1080). This won't be accurate for all users, but will hopefully be close enough. Once the full Angular app loads in the background, their real device screensize will take over.
-3) Run your app in a real browser without SSR and determine the average width/height of the child elements inside virtual-scroller as well as the width/height of the virtual-scroller (or `[parentScroll]` element). Use these values to set the `[ssrChildWidth]`/`[ssrChildHeight]`/`[ssrViewportWidth]`/`[ssrViewportHeight]` properties.
+3) Run your app in a real browser without SSR and determine the average width/height of the child elements inside _virtual-scroller_ as well as the width/height of the _virtual-scroller_ (or `[parentScroll]` element). Use these values to set the `[ssrChildWidth]`/`[ssrChildHeight]`/`[ssrViewportWidth]`/`[ssrViewportHeight]` properties.
 ```html
 <virtual-scroller #scroll [items]="items">
 
@@ -755,7 +757,7 @@ Object.defineProperty(win.document.body.style, 'transform', { value: () => { ret
 The following are known issues that we don't know how to solve or don't have the resources to do so. Please don't submit a ticket for them. If you have an idea on how to fix them, please submit a pull request :)
 
 ### Nested Scrollbars
-If there are 2 nested scrollbars on the page the mouse scrollwheel will only affect the scrollbar of the nearest parent to the current mouse position. This means if you scroll to the bottom of a virtual-scroller using the mousewheel & the window has an extra scrollbar, you cannot use the scrollwheel to scroll the page unless you move the mouse pointer out of the virtual-scroller element.
+If there are 2 nested scrollbars on the page the mouse scrollwheel will only affect the scrollbar of the nearest parent to the current mouse position. This means if you scroll to the bottom of a _virtual-scroller_ using the mousewheel & the window has an extra scrollbar, you cannot use the scrollwheel to scroll the page unless you move the mouse pointer out of the _virtual-scroller_ element.
 
 ## Contributing
 Contributions are very welcome! Just send a pull request. Feel free to contact me or checkout my [GitHub](https://github.com/rintoj) page.

--- a/README.md
+++ b/README.md
@@ -24,35 +24,37 @@ Virtual Scroll displays a virtual, "infinite" list. Supports horizontal/vertical
 This module displays a small subset of records just enough to fill the viewport and uses the same DOM elements as the user scrolls.
 This method is effective because the number of DOM elements are always constant and tiny irrespective of the size of the list. Thus virtual scroll can display an infinitely growing list of items in an efficient way.
 
-	* Supports multi-column
-	* Easy to use apis
-	* OpenSource and available in GitHub
+- Supports multi-column
+- Easy to use APIs
+- Open source and available in GitHub
 
 ## Breaking Changes:
-	* v3.0.0: Several deprecated properties removed (see changelog).
-		If items array is prepended with additional items, keep scroll on currently visible items, if possible. There is no flag to disable this, because it seems to be the best user-experience in all cases. If you disagree, please create an issue.
-	* v2.1.0: Dependency Injection syntax was changed.
-	* v1.0.6: viewPortIndices API property removed. (use viewPortInfo instead)
-	* v1.0.3: Renamed everything from virtual-scroll to virtual-scroller and from virtualScroll to virtualScroller
-	* v0.4.13: resizeBypassRefreshTheshold renamed to resizeBypassRefreshThreshold (typo)
-	* v0.4.12: The start and end values of the change/start/end events were including bufferAmount, which made them confusing. This has been corrected.
-		viewPortIndices.arrayStartIndex renamed to viewPortIndices.startIndex and viewPortIndices.arrayEndIndex renamed to viewPortIndices.endIndex
-	* v0.4.4: The value of IPageInfo.endIndex wasn't intuitive. This has been corrected. Both IPageInfo.startIndex and IPageInfo.endIndex are the 0-based array indexes of the items being rendered in the viewport. (Previously Change.EndIndex was the array index + 1)
 
-NOTE: API methods marked (DEPRECATED) will be removed in the next major version. Please attempt to stop using them in your code & create an issue if you believe they're still necessary.
+- `v3.0.0` Several deprecated properties removed (see changelog).
+    - If items array is prepended with additional items, keep scroll on currently visible items, if possible. There is no flag to disable this, because it seems to be the best user-experience in all cases. If you disagree, please create an issue.
+- `v2.1.0` Dependency Injection syntax was changed.
+- `v1.0.6` viewPortIndices API property removed. (use viewPortInfo instead)
+- `v1.0.3` Renamed everything from _virtual-scroll_ to _virtual-scroller_ and from _virtualScroll_ to _virtualScroller_
+- `v0.4.13` _resizeBypassRefreshTheshold_ renamed to _resizeBypassRefreshThreshold_ (typo)
+- `v0.4.12` The start and end values of the change/start/end events were including bufferAmount, which made them confusing. This has been corrected.
+    - viewPortIndices.arrayStartIndex renamed to viewPortIndices.startIndex and viewPortIndices.arrayEndIndex renamed to viewPortIndices.endIndex
+- `v0.4.4` The value of IPageInfo.endIndex wasn't intuitive. This has been corrected. Both IPageInfo.startIndex and IPageInfo.endIndex are the 0-based array indexes of the items being rendered in the viewport. (Previously Change.EndIndex was the array index + 1)
+
+*Note* - API methods marked *(DEPRECATED)* will be removed in the next major version. Please attempt to stop using them in your code & create an issue if you believe they're still necessary.
 
 ## New features:
-	* RTL Support on Horizontal scrollers
-	* Support for fixed <thead> on <table> elements.
-	* Added API to query for current scroll px position (also passed as argument to IPageInfo listeners)
-	* Added API to invalidate cached child item measurements (if your child item sizes change dynamically)
-	* Added API to scroll to specific px position
-	* If scroll container resizes, the items will auto-refresh. Can be disabled if it causes any performance issues by setting [checkResizeInterval]="0"
-	* useMarginInsteadOfTranslate flag. Defaults to false. This can affect performance (better/worse depending on your circumstances), and also creates a workaround for the transform+position:fixed browser bug.
-	* Support for horizontal scrollbars
-	* Support for elements with different sizes
-	* Added ability to put other elements inside of scroll (Need to wrap list itself in @ContentChild('container'))
-	* Added ability to use any parent with scrollbar instead of this element (@Input() parentScroll)
+
+ - RTL Support on Horizontal scrollers
+ - Support for fixed `<thead>` on `<table>` elements.
+ - Added API to query for current scroll px position (also passed as argument to `IPageInfo` listeners)
+ - Added API to invalidate cached child item measurements (if your child item sizes change dynamically)
+ - Added API to scroll to specific px position
+ - If scroll container resizes, the items will auto-refresh. Can be disabled if it causes any performance issues by setting `[checkResizeInterval]="0"`
+ - `useMarginInsteadOfTranslate` flag. Defaults to _false_. This can affect performance (better/worse depending on your circumstances), and also creates a workaround for the transform+position:fixed browser bug.
+ - Support for horizontal scrollbars
+ - Support for elements with different sizes
+ - Added ability to put other elements inside of scroll (Need to wrap list itself in @ContentChild('container'))
+ - Added ability to use any parent with scrollbar instead of this element (@Input() parentScroll)
 
 ## Demo
 
@@ -206,7 +208,7 @@ In _alphabetical_ order:
 | childHeight *(DEPRECATED)*         | `number`          | The minimum height of the item template's cell. Use this if `enableUnequalChildrenSizes` isn't working well enough. (The actual rendered size of the first cell is used by default if not specified.)
 | childWidth *(DEPRECATED)*          | `number`          | The minimum width of the item template's cell. Use this if `enableUnequalChildrenSizes` isn't working well enough. (The actual rendered size of the first cell is used by default if not specified.)
 
-Note: The Events without the "vs" prefix have been deprecated because they might conflict with native DOM events due to their "bubbling" nature. See https://github.com/angular/angular/issues/13997
+*Note* - The Events without the "vs" prefix have been deprecated because they might conflict with native DOM events due to their "bubbling" nature. See https://github.com/angular/angular/issues/13997
 An example is if an <input> element inside <virtual-scroller> emits a "change" event which bubbles up to the (change) handler of virtual-scroller. Using the vs prefix will prevent this bubbling conflict because there are currently no official DOM events prefixed with vs.
 
 ## Use parent scrollbar
@@ -239,7 +241,7 @@ If the parentScroll is a custom angular component (instead of a native HTML elem
 </custom-angular-component>
 ```
 
-Note: The parent element should have a width and height defined.
+*Note* - The parent element should have a width and height defined.
 
 ## Use scrollbar of window
 
@@ -259,7 +261,7 @@ If you want to use the window's scrollbar, set `parentScroll`.
 
 Items must have fixed height and width for this module to work perfectly. If not, set [enableUnequalChildrenSizes]="true".
 
-(DEPRECATED): If enableUnequalChildrenSizes isn't working, you can set inputs `childWidth` and `childHeight` to their smallest possible values. You can also modify `bufferAmount` which causes extra items to be rendered on the edges of the scrolling area.
+*(DEPRECATED)*: If enableUnequalChildrenSizes isn't working, you can set inputs `childWidth` and `childHeight` to their smallest possible values. You can also modify `bufferAmount` which causes extra items to be rendered on the edges of the scrolling area.
 
 ```html
 <virtual-scroller #scroll [items]="items" [enableUnequalChildrenSizes]="true">
@@ -314,7 +316,7 @@ export class ListWithApiComponent implements OnChanges {
 
 ## With HTML Table
 
-Note: The #header angular selector will make the <thead> element fixed to top. If you want the header to scroll out of view don't add the #header angular element ref.
+*Note* - The #header angular selector will make the `<thead>` element fixed to top. If you want the header to scroll out of view don't add the _#header_ angular element ref.
 
 ```html
 <virtual-scroller #scroll [items]="myItems">
@@ -367,11 +369,11 @@ Example:
 
 ## If container size changes
 
-Note: This should now be auto-detected, however the 'refresh' method can still force it if neeeded.
-	This was implemented using the setInterval method which may cause minor performance issues. It shouldn't be noticeable, but can be disabled via [checkResizeInterval]="0"
-	Performance will be improved once "Resize Observer" (https://wicg.github.io/ResizeObserver/) is fully implemented.
+*Note* - This should now be auto-detected, however the 'refresh' method can still force it if neeeded.
+    This was implemented using the setInterval method which may cause minor performance issues. It shouldn't be noticeable, but can be disabled via `[checkResizeInterval]="0"`
+    Performance will be improved once "Resize Observer" (https://wicg.github.io/ResizeObserver/) is fully implemented.
 
-Refresh method (DEPRECATED)
+Refresh method *(DEPRECATED)*
 If virtual scroll is used within a dropdown or collapsible menu, virtual scroll needs to know when the container size changes. Use `refresh()` function after container is resized (include time for animation as well).
 
 ```ts
@@ -691,9 +693,11 @@ public class MainComponent {
 </virtual-scroller>
 ```
 
-Note: `executeRefreshOutsideAngularZone` will disable Angular ChangeDetection during all virtual-scroller events, including: vsUpdate, vsStart, vsEnd, vsChange. If you change any data-bound properties inside these event handlers, you must perform manual change detection on those specific components. This can be done via changeDetectorRef.detectChanges() at the end of the event handler. Note: The changeDetectorRef is component-specific, so you'll need to inject it into a private variable in the constructor of the appropriate component before calling it in response to the virtual-scroller events.
+*Note* - `executeRefreshOutsideAngularZone` will disable Angular ChangeDetection during all virtual-scroller events, including: vsUpdate, vsStart, vsEnd, vsChange. If you change any data-bound properties inside these event handlers, you must perform manual change detection on those specific components. This can be done via `changeDetectorRef.detectChanges()` at the end of the event handler.
 
-:warning: WARNING - Failure to perform manual change detection in response to _virtual-scroller_ events will cause your components to render a stale UI for a short time (until the next Change Detection cycle), which will make your app feel buggy.
+*Note* - The `changeDetectorRef` is component-specific, so you'll need to inject it into a private variable in the constructor of the appropriate component before calling it in response to the virtual-scroller events.
+
+:warning: *WARNING* - Failure to perform manual change detection in response to _virtual-scroller_ events will cause your components to render a stale UI for a short time (until the next Change Detection cycle), which will make your app feel buggy.
 
 *Note* - `changeDetectorRef.detectChanges()` will execute change detection on the component and all its nested children. If multiple components need to run change detection in response to a virtual-scroller event, you can call detectChanges from a higher-level component in the ancestor hierarchy rather than on each individual component. However, its important to avoid too many extra change detection cycles by not going too high in the hierarchy unless all the nested children really need to have change detection performed.
 

--- a/README.md
+++ b/README.md
@@ -318,24 +318,24 @@ Note: The #header angular selector will make the <thead> element fixed to top. I
 
 ```html
 <virtual-scroller #scroll [items]="myItems">
-	<table>
-		<thead #header>
-			<th>Index</th>
-			<th>Name</th>
-			<th>Gender</th>
-			<th>Age</th>
-			<th>Address</th>
-		</thead>
-		<tbody #container>
-			<tr *ngFor="let item of scroll.viewPortItems">
-				<td>{{item.index}}</td>
-				<td>{{item.name}}</td>
-				<td>{{item.gender}}</td>
-				<td>{{item.age}}</td>
-				<td>{{item.address}}</td>
-			</tr>
-		</tbody>
-	</table>
+    <table>
+        <thead #header>
+            <th>Index</th>
+            <th>Name</th>
+            <th>Gender</th>
+            <th>Age</th>
+            <th>Address</th>
+        </thead>
+        <tbody #container>
+            <tr *ngFor="let item of scroll.viewPortItems">
+                <td>{{item.index}}</td>
+                <td>{{item.name}}</td>
+                <td>{{item.gender}}</td>
+                <td>{{item.age}}</td>
+                <td>{{item.address}}</td>
+            </tr>
+        </tbody>
+    </table>
 </virtual-scroller>
 ```
 

--- a/README.md
+++ b/README.md
@@ -201,15 +201,16 @@ In _alphabetical_ order:
 | useMarginInsteadOfTranslate        | `boolean` false   | Translate is faster in many scenarios because it can use GPU acceleration, but it can be slower if your scroll container or child elements don't use any transitions or opacity. More importantly, translate creates a new "containing block" which breaks position:fixed because it'll be relative to the transform rather than the window. If you're experiencing issues with position:fixed on your child elements, turn this flag on.
 | viewPortInfo                       | `IPageInfo`       | Allows querying the the current viewport info on demand rather than listening for events.
 | viewPortItems                      | any[]             | The array of items currently being rendered to the viewport.
-| vsChange                           | Event<IPageInfo>  | This event is fired every time the `start` or `end` indexes or scroll position change and emits `IPageInfo`.
-| vsEnd                              | Event<IPageInfo>  | This event is fired every time `end` index changes and emits `IPageInfo`.
-| vsStart                            | Event<IPageInfo>  | This event is fired every time `start` index changes and emits `IPageInfo`.
-| vsUpdate                           | Event<any[]>      | This event is fired every time the `start` or `end` indexes change and emits the list of items which should be visible based on the current scroll position from `start` to `end`. The list emitted by this event must be used with `*ngFor` to render the actual list of items within `<virtual-scroller>`
+| vsChange                           | `Event<IPageInfo>`| This event is fired every time the `start` or `end` indexes or scroll position change and emits `IPageInfo`.
+| vsEnd                              | `Event<IPageInfo>`| This event is fired every time `end` index changes and emits `IPageInfo`.
+| vsStart                            | `Event<IPageInfo>`| This event is fired every time `start` index changes and emits `IPageInfo`.
+| vsUpdate                           | `Event<any[]>`    | This event is fired every time the `start` or `end` indexes change and emits the list of items which should be visible based on the current scroll position from `start` to `end`. The list emitted by this event must be used with `*ngFor` to render the actual list of items within `<virtual-scroller>`
 | childHeight *(DEPRECATED)*         | `number`          | The minimum height of the item template's cell. Use this if `enableUnequalChildrenSizes` isn't working well enough. (The actual rendered size of the first cell is used by default if not specified.)
 | childWidth *(DEPRECATED)*          | `number`          | The minimum width of the item template's cell. Use this if `enableUnequalChildrenSizes` isn't working well enough. (The actual rendered size of the first cell is used by default if not specified.)
 
 *Note* - The Events without the "vs" prefix have been deprecated because they might conflict with native DOM events due to their "bubbling" nature. See https://github.com/angular/angular/issues/13997
-An example is if an <input> element inside <virtual-scroller> emits a "change" event which bubbles up to the (change) handler of virtual-scroller. Using the vs prefix will prevent this bubbling conflict because there are currently no official DOM events prefixed with vs.
+
+An example is if an `<input>` element inside `<virtual-scroller>` emits a "change" event which bubbles up to the (change) handler of virtual-scroller. Using the vs prefix will prevent this bubbling conflict because there are currently no official DOM events prefixed with vs.
 
 ## Use parent scrollbar
 

--- a/README.md
+++ b/README.md
@@ -438,37 +438,37 @@ export class ListComponent {
 Some default config settings can be overridden via DI, so you can set them globally instead of on each instance of virtual-scroller.
 
 ```ts
- providers: [
-		provide: 'virtual-scroller-default-options', useValue: {
-			scrollThrottlingTime: 0,
-			scrollDebounceTime: 0,
-			scrollAnimationTime: 750,
-			checkResizeInterval: 1000,
-			resizeBypassRefreshThreshold: 5,
-			modifyOverflowStyleOfParentScroll: true,
-			stripedTable: false
-		}
-  ],
+providers: [
+    provide: 'virtual-scroller-default-options', useValue: {
+        checkResizeInterval: 1000,
+        modifyOverflowStyleOfParentScroll: true,
+        resizeBypassRefreshThreshold: 5,
+        scrollAnimationTime: 750,
+        scrollDebounceTime: 0,
+        scrollThrottlingTime: 0,
+        stripedTable: false
+    }
+],
 ```
 
 OR
 
 ```ts
 export function vsDefaultOptionsFactory(): VirtualScrollerDefaultOptions {
-	return {
-		scrollThrottlingTime: 0,
-		scrollDebounceTime: 0,
-		scrollAnimationTime: 750,
-		checkResizeInterval: 1000,
-		resizeBypassRefreshThreshold: 5,
-		modifyOverflowStyleOfParentScroll: true,
-		stripedTable: false
-	};
+    return {
+        checkResizeInterval: 1000,
+        modifyOverflowStyleOfParentScroll: true,
+        resizeBypassRefreshThreshold: 5,
+        scrollAnimationTime: 750,
+        scrollDebounceTime: 0,
+        scrollThrottlingTime: 0,
+        stripedTable: false
+    };
 }
 
- providers: [
-		provide: 'virtual-scroller-default-options', useFactory: vsDefaultOptionsFactory
-  ],
+providers: [
+    provide: 'virtual-scroller-default-options', useFactory: vsDefaultOptionsFactory
+],
 ```
 
 ## Sorting Items

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ In _alphabetical_ order:
 | invalidateCachedMeasurementAtIndex | `Function`        | `(index:number)=>void` - to force re-measuring cached item size.
 | invalidateCachedMeasurementForItem | `Function`        | `(item:any)=>void` - to force re-measuring cached item size.
 | items                              | any[]             | The data that builds the templates within the virtual scroll. This is the same data that you'd pass to `ngFor`. It's important to note that when this data has changed, then the entire virtual scroll is refreshed.
-| modifyOverflowStyleOfParentScroll  | `boolean` true    | Set to false if you want to prevent ngx-virtual-scroller from automatically changing the overflow style setting of the parentScroll element to 'scroll'.
+| modifyOverflowStyleOfParentScroll  | `boolean` true    | Set to false if you want to prevent _ngx-virtual-scroller_ from automatically changing the overflow style setting of the parentScroll element to 'scroll'.
 | parentScroll                       | Element / Window  | Element (or window), which will have scrollbar. This element must be one of the parents of virtual-scroller
 | refresh                            | `Function`        | `()=>void` - to force re-rendering of current items in viewport.
 | RTL                                | `boolean` false   | Set to `true` if you want horizontal slider to support right to left script (RTL).
@@ -343,7 +343,7 @@ export class ListWithApiComponent implements OnChanges {
 ```
 
 ## If child size changes
-virtual-scroller caches the measurements for the rendered items. If `enableUnequalChildrenSizes===true` then each item is measured and cached separately. Otherwise, the 1st measured item is used for all items.
+_virtual-scroller_ caches the measurements for the rendered items. If `enableUnequalChildrenSizes===true` then each item is measured and cached separately. Otherwise, the 1st measured item is used for all items.
 
 If your items can change sizes dynamically, you'll need to notify _virtual-scroller_ to re-measure them. There are 3 methods for doing this:
 ```ts
@@ -353,7 +353,7 @@ virtualScroller.invalidateCachedMeasurementAtIndex(index: number);
 ```
 
 ## If child view state is reverted after scrolling away & back
-virtual-scroller essentially uses *ngIf to remove items that are scrolled out of view. This is what gives the performance benefits compared to keeping all the off-screen items in the DOM.
+_virtual-scroller_ essentially uses `*ngIf` to remove items that are scrolled out of view. This is what gives the performance benefits compared to keeping all the off-screen items in the DOM.
 
 Because of the *ngIf, Angular completely forgets any view state. If your component has the ability to change state, it's your app's responsibility to retain that viewstate in your own object which data-binds to the component.
 
@@ -373,7 +373,7 @@ Example:
 
 *Note* - This should now be auto-detected, however the 'refresh' method can still force it if neeeded.
 
-This was implemented using the setInterval method which may cause minor performance issues. It shouldn't be noticeable, but can be disabled via `[checkResizeInterval]="0"`
+This was implemented using the `setInterval` method which may cause minor performance issues. It shouldn't be noticeable, but can be disabled via `[checkResizeInterval]="0"`
 
 Performance will be improved once "Resize Observer" (https://wicg.github.io/ResizeObserver/) is fully implemented.
 
@@ -519,7 +519,7 @@ If you want to nest additional elements inside virtual scroll besides the list i
 
 ## Performance - TrackBy
 
-virtual-scroller uses `*ngFor` to render the visible items. When an `*ngFor` array changes, Angular uses a _trackBy_ function to determine if it should re-use or re-generate each component in the loop.
+_virtual-scroller_ uses `*ngFor` to render the visible items. When an `*ngFor` array changes, Angular uses a _trackBy_ function to determine if it should re-use or re-generate each component in the loop.
 
 For example, if 5 items are visible and scrolling causes 1 item to swap out but the other 4 remain visible, there's no reason Angular should re-generate those 4 components from scratch, it should reuse them.
 
@@ -665,7 +665,7 @@ public class SomeRandomComponentWhichUsesOnPush {
     }
 }
 ```
-The ManualChangeDetection/Util classes are helpers that can be copy/pasted directly into your app. The code for MyEntryLevelAppComponent & SomeRandomComponentWhichUsesOnPush are examples that you'll need to modify for your specific app. If you follow this pattern, _OnPush_ is much easier to implement. However, the really hard part is analyzing all of your code to determine *where* you're mutating state. Unfortunately there's no magic bullet for this, you'll need to spend a lot of time reading/debugging/testing your code.
+The _ManualChangeDetection/Util_ classes are helpers that can be copy/pasted directly into your app. The code for _MyEntryLevelAppComponent_ & _SomeRandomComponentWhichUsesOnPush_ are examples that you'll need to modify for your specific app. If you follow this pattern, _OnPush_ is much easier to implement. However, the really hard part is analyzing all of your code to determine *where* you're mutating state. Unfortunately there's no magic bullet for this, you'll need to spend a lot of time reading/debugging/testing your code.
 
 ## Performance - executeRefreshOutsideAngularZone
 
@@ -674,7 +674,9 @@ This API is meant as a quick band-aid fix for performance issues. Please read th
 `ChangeDetectionStrategy.OnPush` is the recommended strategy as it improves the entire app performance, not just _virtual-scroller_. However, `ChangeDetectionStrategy.OnPush` is hard to implement. `executeRefreshOutsideAngularZone` may be an easier initial approach until you're ready to tackle `ChangeDetectionStrategy.OnPush`.
 
 If you've correctly implemented `ChangeDetectionStrategy.OnPush` for 100% of your components, the `executeRefreshOutsideAngularZone` will not provide any performance benefit.
+
 If you have not yet done this, scrolling may feel slow. This is because Angular performs a full-app change detection while scrolling. However, it's likely that only the components inside the scroller actually need the change detection to run, so a full-app change detection cycle is overkill.
+
 In this case you can get a free/easy performance boost with the following code:
 ```ts
 import { ChangeDetectorRef } from '@angular/core';
@@ -723,7 +725,7 @@ If both Debounce & Throttling are set, debounce takes precedence.
 
 The initial SSR render isn't a fully functioning site, it's essentially an HTML "screenshot" (HTML/CSS, but no JS). However, it immediately swaps out your "screenshot" with the real site as soon as the full app has downloaded in the background. The intent of SSR is to give a correct visual very quickly, because a full angular app could take a long time to download. This makes the user *think* your site is fast, because hopefully they won't click on anything that requires JS before the fully-functioning site has finished loading in the background. Also, it allows screen scrapers without JavaScript to work correctly (example: Facebook posts/etc).
 
-virtual-scroller relies on JavaScript APIs to measure the size of child elements and the scrollable area of their parent. These APIs do not work in SSR because the HTML/CSS "screenshot" is generated on the server via Node, it doesn't execute/render the site as a browser would. This means _virtual-scroller_ will see all measurements as undefined and the "screenshot" will not be generated correctly. Most likely, only 1 child element will appear in your _virtual-scroller_. This "screenshot" can be fixed with polyfills. However, when the browser renders the "screenshot", the scrolling behaviour still won't work until the full app has loaded.
+_virtual-scroller_ relies on JavaScript APIs to measure the size of child elements and the scrollable area of their parent. These APIs do not work in SSR because the HTML/CSS "screenshot" is generated on the server via Node, it doesn't execute/render the site as a browser would. This means _virtual-scroller_ will see all measurements as undefined and the "screenshot" will not be generated correctly. Most likely, only 1 child element will appear in your _virtual-scroller_. This "screenshot" can be fixed with polyfills. However, when the browser renders the "screenshot", the scrolling behaviour still won't work until the full app has loaded.
 
 SSR is an advanced (and complex) topic that can't be fully addressed here. Please research this on your own. However, here are some suggestions:
 1) Use https://www.npmjs.com/package/domino and https://www.npmjs.com/package/raf polyfills in your `main.server.ts` file

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 Virtual Scroll displays a virtual, "infinite" list. Supports horizontal/vertical, variable heights, & multi-column.
 
-## Renamed from angular2-virtual-scroll to ngx-virtual-scroller. Please update your package.json
+## Renamed from `angular2-virtual-scroll` to `ngx-virtual-scroller`. Please update your _package.json_
 
 ## About
 
@@ -53,7 +53,7 @@ NOTE: API methods marked (DEPRECATED) will be removed in the next major version.
 	* Support for elements with different sizes
 	* Added ability to put other elements inside of scroll (Need to wrap list itself in @ContentChild('container'))
 	* Added ability to use any parent with scrollbar instead of this element (@Input() parentScroll)
- 
+
 ## Demo
 
 [See Demo Here](http://rintoj.github.io/ngx-virtual-scroller)
@@ -137,9 +137,9 @@ my-custom-component {
 }
 ```
 
-**Step 4:** Create 'my-custom-component' component.
+**Step 4:** Create `my-custom-component` component.
 
-'my-custom-component' must be a custom angular2 component, outside of this library.
+`my-custom-component` must be a custom _angular_ component, outside of this library.
 
 Child component is not necessary if your item is simple enough. See below.
 
@@ -164,45 +164,45 @@ interface IPageInfo {
 
 ## API
 
-| Attribute      | Type   | Description
-|----------------|--------|------------
-| checkResizeInterval | number | How often in milliseconds to check if virtual-scroller (or parentScroll) has been resized. If resized, it'll call Refresh() method. Defaults to 1000.
-| resizeBypassRefreshThreshold | number | How many pixels to ignore during resize check if virtual-scroller (or parentScroll) are only resized by a very small amount. Defaults to 5.
-| enableUnequalChildrenSizes | boolean | If you want to use the "unequal size" children feature. This is not perfect, but hopefully "close-enough" for most situations. Defaults to false.
-| scrollDebounceTime | number | Milliseconds to delay refreshing viewport if user is scrolling quickly (for performance reasons). Default is 0.
-| scrollThrottlingTime | number | Milliseconds to delay refreshing viewport if user is scrolling quickly (for performance reasons). Default is 0.
-| useMarginInsteadOfTranslate | boolean | Defaults to false. Translate is faster in many scenarios because it can use GPU acceleration, but it can be slower if your scroll container or child elements don't use any transitions or opacity. More importantly, translate creates a new "containing block" which breaks position:fixed because it'll be relative to the transform rather than the window. If you're experiencing issues with position:fixed on your child elements, turn this flag on.
-| modifyOverflowStyleOfParentScroll | boolean | Defaults to true. Set to false if you want to prevent ngx-virtual-scroller from automatically changing the overflow style setting of the parentScroll element to 'scroll'.
-| scrollbarWidth | number | If you want to override the auto-calculated scrollbar width. This is used to determine the dimensions of the viewable area when calculating the number of items to render.
-| scrollbarHeight | number | If you want to override the auto-calculated scrollbar height. This is used to determine the dimensions of the viewable area when calculating the number of items to render.
-| horizontal | boolean | Whether the scrollbars should be vertical or horizontal. Defaults to false.
-| items          | any[]  | The data that builds the templates within the virtual scroll. This is the same data that you'd pass to ngFor. It's important to note that when this data has changed, then the entire virtual scroll is refreshed.
-| stripedTable          | boolean  | Defaults to false. Set to true if you use a striped table. In this case, the rows will be added/removed two by two to keep the strips consistent.
-| childWidth (DEPRECATED)     | number | The minimum width of the item template's cell. Use this if enableUnequalChildrenSizes isn't working well enough. (The actual rendered size of the first cell is used by default if not specified.)
-| childHeight (DEPRECATED)    | number | The minimum height of the item template's cell. Use this if enableUnequalChildrenSizes isn't working well enough. (The actual rendered size of the first cell is used by default if not specified.)
-| bufferAmount | number | The number of elements to be rendered above & below the current container's viewport. Increase this if enableUnequalChildrenSizes isn't working well enough. (defaults to enableUnequalChildrenSizes ? 5 : 0)
-| scrollAnimationTime | number | The time in milliseconds for the scroll animation to run for. Default value is 750. 0 will completely disable the tween/animation.
-| parentScroll   | Element / Window | Element (or window), which will have scrollbar. This element must be one of the parents of virtual-scroller
-| compareItems   | Function | Predicate of syntax (item1:any, item2:any)=>boolean which is used when items array is modified to determine which items have been changed (determines if cached child size measurements need to be refreshed or not for enableUnequalChildrenSizes). Defaults to === comparison.
-| vsStart         | Event<IPageInfo>  | This event is fired every time `start` index changes and emits `IPageInfo`.
-| vsEnd         | Event<IPageInfo>  | This event is fired every time `end` index changes and emits `IPageInfo`.
-| vsChange         | Event<IPageInfo>  | This event is fired every time the `start` or `end` indexes or scroll position change and emits `IPageInfo`.
-| vsUpdate         | Event<any[]>  | This event is fired every time the `start` or `end` indexes change and emits the list of items which should be visible based on the current scroll position from `start` to `end`. The list emitted by this event must be used with `*ngFor` to render the actual list of items within `<virtual-scroller>`
-| viewPortInfo | IPageInfo | Allows querying the the current viewport info on demand rather than listening for events.
-| viewPortItems | any[] | The array of items currently being rendered to the viewport.
-| refresh | ()=>void | Function to force re-rendering of current items in viewport.
+| Attribute      | Type   | Description | Default
+|----------------|--------|-------------| -------
+| bufferAmount | number | The number of elements to be rendered above & below the current container's viewport. Increase this if enableUnequalChildrenSizes isn't working well enough. | enableUnequalChildrenSizes ? 5 : 0
+| checkResizeInterval | number | How often in milliseconds to check if virtual-scroller (or parentScroll) has been resized. If resized, it'll call Refresh() method | 1000
+| compareItems   | Function | Predicate of syntax (item1:any, item2:any)=>boolean which is used when items array is modified to determine which items have been changed (determines if cached child size measurements need to be refreshed or not for enableUnequalChildrenSizes). | === comparison
+| enableUnequalChildrenSizes | boolean | If you want to use the "unequal size" children feature. This is not perfect, but hopefully "close-enough" for most situations. | false
+| executeRefreshOutsideAngularZone | boolean | Disables full-app Angular ChangeDetection while scrolling, which can give a performance boost. Requires developer to manually execute change detection on any components which may have changed. USE WITH CAUTION - Read the "Performance" section below. | false
+| horizontal | boolean | Whether the scrollbars should be vertical or horizontal. | false
 | invalidateAllCachedMeasurements | ()=>void | Function to force re-measuring *all* cached item sizes. If enableUnequalChildrenSizes===false, only 1 item will be re-measured.
-| invalidateCachedMeasurementForItem | (item:any)=>void | Function to force re-measuring cached item size.
 | invalidateCachedMeasurementAtIndex | (index:number)=>void | Function to force re-measuring cached item size.
+| invalidateCachedMeasurementForItem | (item:any)=>void | Function to force re-measuring cached item size.
+| items          | any[]  | The data that builds the templates within the virtual scroll. This is the same data that you'd pass to ngFor. It's important to note that when this data has changed, then the entire virtual scroll is refreshed.
+| modifyOverflowStyleOfParentScroll | boolean | Set to false if you want to prevent ngx-virtual-scroller from automatically changing the overflow style setting of the parentScroll element to 'scroll'. | true
+| parentScroll   | Element / Window | Element (or window), which will have scrollbar. This element must be one of the parents of virtual-scroller
+| refresh | ()=>void | Function to force re-rendering of current items in viewport.
+| RTL | boolean | Set to true if you want horizontal slider to support RTL. | false
+| resizeBypassRefreshThreshold | number | How many pixels to ignore during resize check if virtual-scroller (or parentScroll) are only resized by a very small amount. | 5
+| scrollAnimationTime | number | The time in milliseconds for the scroll animation to run for. 0 will completely disable the tween/animation. | 750
+| scrollDebounceTime | number | Milliseconds to delay refreshing viewport if user is scrolling quickly (for performance reasons). | 0
 | scrollInto | (item:any, alignToBeginning:boolean = true, additionalOffset:number = 0, animationMilliseconds:number = undefined, animationCompletedCallback:()=>void = undefined)=>void | Scrolls to item
+| scrollThrottlingTime | number | Milliseconds to delay refreshing viewport if user is scrolling quickly (for performance reasons). | 0
 | scrollToIndex | (index:number, alignToBeginning:boolean = true, additionalOffset:number = 0, animationMilliseconds:number = undefined, animationCompletedCallback:()=>void = undefined)=>void | Scrolls to item at index
 | scrollToPosition | (scrollPosition:number, animationMilliseconds:number = undefined, animationCompletedCallback: ()=>void = undefined)=>void | Scrolls to px position
-| ssrChildWidth | number | The hard-coded width of the item template's cell to use if rendering via Angular Universal/Server-Side-Rendering
+| scrollbarHeight | number | If you want to override the auto-calculated scrollbar height. This is used to determine the dimensions of the viewable area when calculating the number of items to render.
+| scrollbarWidth | number | If you want to override the auto-calculated scrollbar width. This is used to determine the dimensions of the viewable area when calculating the number of items to render.
 | ssrChildHeight | number | The hard-coded height of the item template's cell to use if rendering via Angular Universal/Server-Side-Rendering
-| ssrViewportWidth | number | The hard-coded visible width of the virtual-scroller (or [parentScroll]) to use if rendering via Angular Universal/Server-Side-Rendering. Defaults to 1920.
-| ssrViewportHeight | number | The hard-coded visible height of the virtual-scroller (or [parentScroll]) to use if rendering via Angular Universal/Server-Side-Rendering. Defaults to 1080.
-| executeRefreshOutsideAngularZone | boolean | Defaults to false. Disables full-app Angular ChangeDetection while scrolling, which can give a performance boost. Requires developer to manually execute change detection on any components which may have changed. USE WITH CAUTION - Read the "Performance" section below.
-| RTL | boolean | Defaults to false. Set to true if you want horizontal slider to support RTL.
+| ssrChildWidth | number | The hard-coded width of the item template's cell to use if rendering via Angular Universal/Server-Side-Rendering
+| ssrViewportHeight | number | The hard-coded visible height of the virtual-scroller (or [parentScroll]) to use if rendering via Angular Universal/Server-Side-Rendering. | 1080
+| ssrViewportWidth | number | The hard-coded visible width of the virtual-scroller (or [parentScroll]) to use if rendering via Angular Universal/Server-Side-Rendering. | 1920
+| stripedTable          | boolean  | Set to true if you use a striped table. In this case, the rows will be added/removed two by two to keep the strips consistent. | false
+| useMarginInsteadOfTranslate | boolean | Translate is faster in many scenarios because it can use GPU acceleration, but it can be slower if your scroll container or child elements don't use any transitions or opacity. More importantly, translate creates a new "containing block" which breaks position:fixed because it'll be relative to the transform rather than the window. If you're experiencing issues with position:fixed on your child elements, turn this flag on. | false
+| viewPortInfo | IPageInfo | Allows querying the the current viewport info on demand rather than listening for events.
+| viewPortItems | any[] | The array of items currently being rendered to the viewport.
+| vsChange         | Event<IPageInfo>  | This event is fired every time the `start` or `end` indexes or scroll position change and emits `IPageInfo`.
+| vsEnd         | Event<IPageInfo>  | This event is fired every time `end` index changes and emits `IPageInfo`.
+| vsStart         | Event<IPageInfo>  | This event is fired every time `start` index changes and emits `IPageInfo`.
+| vsUpdate         | Event<any[]>  | This event is fired every time the `start` or `end` indexes change and emits the list of items which should be visible based on the current scroll position from `start` to `end`. The list emitted by this event must be used with `*ngFor` to render the actual list of items within `<virtual-scroller>`
+| childHeight (DEPRECATED)    | number | The minimum height of the item template's cell. Use this if enableUnequalChildrenSizes isn't working well enough. (The actual rendered size of the first cell is used by default if not specified.)
+| childWidth (DEPRECATED)     | number | The minimum width of the item template's cell. Use this if enableUnequalChildrenSizes isn't working well enough. (The actual rendered size of the first cell is used by default if not specified.)
 
 Note: The Events without the "vs" prefix have been deprecated because they might conflict with native DOM events due to their "bubbling" nature. See https://github.com/angular/angular/issues/13997
 An example is if an <input> element inside <virtual-scroller> emits a "change" event which bubbles up to the (change) handler of virtual-scroller. Using the vs prefix will prevent this bubbling conflict because there are currently no official DOM events prefixed with vs.
@@ -346,7 +346,7 @@ virtualScroller.invalidateCachedMeasurementForItem(item: any);
 virtualScroller.invalidateCachedMeasurementAtIndex(index: number);
 ```
 
-## If child view state is reverted after scrolling away & back 
+## If child view state is reverted after scrolling away & back
 virtual-scroller essentially uses *ngIf to remove items that are scrolled out of view. This is what gives the performance benefits compared to keeping all the off-screen items in the DOM.
 
 Because of the *ngIf, Angular completely forgets any view state. If your component has the ability to change state, it's your app's responsibility to retain that viewstate in your own object which data-binds to the component.
@@ -486,7 +486,7 @@ This hacky CSS allows hiding a scrollbar while still enabling scroll through mou
 	//hide vertical scrollbar
 	   margin-right: -25px;
 	   padding-right: 25px;
-	
+
 	//hide horizontal scrollbar
 	   margin-bottom: -25px;
 	   padding-bottom: 25px;
@@ -510,7 +510,7 @@ If you want to nest additional elements inside virtual scroll besides the list i
 
 virtual-scroller uses *ngFor to render the visible items. When an *ngFor array changes, Angular uses a trackBy function to determine if it should re-use or re-generate each component in the loop.
 For example, if 5 items are visible and scrolling causes 1 item to swap out but the other 4 remain visible, there's no reason Angular should re-generate those 4 components from scratch, it should reuse them.
-A trackBy function must return either a number or string as a unique identifier for your object. 
+A trackBy function must return either a number or string as a unique identifier for your object.
 If the array used by *ngFor is of type number[] or string[], Angular's default trackBy function will work automatically, you don't need to do anything extra.
 If the array used by *ngFor is of type any[], you must code your own trackBy function.
 
@@ -570,10 +570,10 @@ public class ManualChangeDetection {
 
 		ManualChangeDetection.STATIC_APPLICATION_REF.tick();
 	}, 5);
-	
+
 	constructor(private changeDetectorRef: ChangeDetectorRef) {
 	}
-}  
+}
 
 //note: this portion is only needed if you don't already have a debounce implementation in your app
 public class Util {
@@ -619,7 +619,7 @@ public class Util {
 
         return result;
     }
-}  
+}
 
 public class MyEntryLevelAppComponent
 {
@@ -638,23 +638,23 @@ public class SomeRandomComponentWhichUsesOnPush {
 	constructor(changeDetectorRef: ChangeDetectorRef) {
 		this.manualChangeDetection = new ManualChangeDetection(changeDetectorRef);
 	}
-	
+
 	public someFunctionThatMutatesState(): void {
 		this.someBoundProperty = someNewValue;
-		
+
 		this.manualChangeDetection.queueChangeDetection();
 	}
 }
 ```
 The ManualChangeDetection/Util classes are helpers that can be copy/pasted directly into your app. The code for MyEntryLevelAppComponent & SomeRandomComponentWhichUsesOnPush are examples that you'll need to modify for your specific app. If you follow this pattern, OnPush is much easier to implement. However, the really hard part is analyzing all of your code to determine *where* you're mutating state. Unfortunately there's no magic bullet for this, you'll need to spend a lot of time reading/debugging/testing your code.
 
-## Performance - executeRefreshOutsideAngularZone 
+## Performance - executeRefreshOutsideAngularZone
 
 This API is meant as a quick band-aid fix for performance issues. Please read the other performance sections above to learn the ideal way to fix performance issues.
 
 ChangeDetectionStrategy.OnPush is the recommended strategy as it improves the entire app performance, not just virtual-scroller. However, ChangeDetectionStrategy.OnPush is hard to implement. executeRefreshOutsideAngularZone may be an easier initial approach until you're ready to tackle ChangeDetectionStrategy.OnPush.
 
-If you've correctly implemented ChangeDetectionStrategy.OnPush for 100% of your components, the executeRefreshOutsideAngularZone will not provide any performance benefit. 
+If you've correctly implemented ChangeDetectionStrategy.OnPush for 100% of your components, the executeRefreshOutsideAngularZone will not provide any performance benefit.
 If you have not yet done this, scrolling may feel slow. This is because Angular performs a full-app change detection while scrolling. However, it's likely that only the components inside the scroller actually need the change detection to run, so a full-app change detection cycle is overkill.
 In this case you can get a free/easy performance boost with the following code:
 ```ts

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ If you want to use the scrollbar of a parent element, set `parentScroll` to a na
 </div>
 ```
 
-If the parentScroll is a custom angular component (instead of a native HTML element such as DIV), Angular will wrap the `#scrollingBlock` variable in an ElementRef https://angular.io/api/core/ElementRef in which case you'll need to use the `.nativeElement` property to get to the underlying JavasSript DOM element reference.
+If the parentScroll is a custom angular component (instead of a native HTML element such as DIV), Angular will wrap the `#scrollingBlock` variable in an ElementRef https://angular.io/api/core/ElementRef in which case you'll need to use the `.nativeElement` property to get to the underlying JavaScript DOM element reference.
 
 ```html
 <custom-angular-component #scrollingBlock>
@@ -721,9 +721,9 @@ If both Debounce & Throttling are set, debounce takes precedence.
 
 ## Angular Universal / Server-Side Rendering
 
-The initial SSR render isn't a fully functioning site, it's essentially an HTML "screenshot" (HTML/CSS, but no JS). However, it immediately swaps out your "screenshot" with the real site as soon as the full app has downloaded in the background. The intent of SSR is to give a correct visual very quickly, because a full angular app could take a long time to download. This makes the user *think* your site is fast, because hopefully they won't click on anything that requires JS before the fully-functioning site has finished loading in the background. Also, it allows screen scrapers without JavasSript to work correctly (example: Facebook posts/etc).
+The initial SSR render isn't a fully functioning site, it's essentially an HTML "screenshot" (HTML/CSS, but no JS). However, it immediately swaps out your "screenshot" with the real site as soon as the full app has downloaded in the background. The intent of SSR is to give a correct visual very quickly, because a full angular app could take a long time to download. This makes the user *think* your site is fast, because hopefully they won't click on anything that requires JS before the fully-functioning site has finished loading in the background. Also, it allows screen scrapers without JavaScript to work correctly (example: Facebook posts/etc).
 
-virtual-scroller relies on JavasSript APIs to measure the size of child elements and the scrollable area of their parent. These APIs do not work in SSR because the HTML/CSS "screenshot" is generated on the server via Node, it doesn't execute/render the site as a browser would. This means _virtual-scroller_ will see all measurements as undefined and the "screenshot" will not be generated correctly. Most likely, only 1 child element will appear in your _virtual-scroller_. This "screenshot" can be fixed with polyfills. However, when the browser renders the "screenshot", the scrolling behaviour still won't work until the full app has loaded.
+virtual-scroller relies on JavaScript APIs to measure the size of child elements and the scrollable area of their parent. These APIs do not work in SSR because the HTML/CSS "screenshot" is generated on the server via Node, it doesn't execute/render the site as a browser would. This means _virtual-scroller_ will see all measurements as undefined and the "screenshot" will not be generated correctly. Most likely, only 1 child element will appear in your _virtual-scroller_. This "screenshot" can be fixed with polyfills. However, when the browser renders the "screenshot", the scrolling behaviour still won't work until the full app has loaded.
 
 SSR is an advanced (and complex) topic that can't be fully addressed here. Please research this on your own. However, here are some suggestions:
 1) Use https://www.npmjs.com/package/domino and https://www.npmjs.com/package/raf polyfills in your `main.server.ts` file

--- a/README.md
+++ b/README.md
@@ -166,20 +166,20 @@ interface IPageInfo {
 
 | Attribute                          | `Type` & Default  | Description
 |------------------------------------|-------------------|--------------|
-| bufferAmount                       | `number` enableUnequalChildrenSizes ? 5 : 0 | The number of elements to be rendered above & below the current container's viewport. Increase this if enableUnequalChildrenSizes isn't working well enough.
-| checkResizeInterval                | `number` 1000     | How often in milliseconds to check if virtual-scroller (or parentScroll) has been resized. If resized, it'll call Refresh() method
-| compareItems                       | `Function` === comparison | Predicate of syntax (item1:any, item2:any)=>boolean which is used when items array is modified to determine which items have been changed (determines if cached child size measurements need to be refreshed or not for enableUnequalChildrenSizes).
+| bufferAmount                       | `number` enableUnequalChildrenSizes ? 5 : 0 | The number of elements to be rendered above & below the current container's viewport. Increase this if `enableUnequalChildrenSizes` isn't working well enough.
+| checkResizeInterval                | `number` 1000     | How often in milliseconds to check if virtual-scroller (or parentScroll) has been resized. If resized, it'll call `Refresh()` method
+| compareItems                       | `Function` === comparison | Predicate of syntax `(item1:any, item2:any)=>boolean` which is used when items array is modified to determine which items have been changed (determines if cached child size measurements need to be refreshed or not for `enableUnequalChildrenSizes`).
 | enableUnequalChildrenSizes         | `boolean` false   | If you want to use the "unequal size" children feature. This is not perfect, but hopefully "close-enough" for most situations.
 | executeRefreshOutsideAngularZone   | `boolean` false   | Disables full-app Angular ChangeDetection while scrolling, which can give a performance boost. Requires developer to manually execute change detection on any components which may have changed. USE WITH CAUTION - Read the "Performance" section below.
 | horizontal                         | `boolean` false   | Whether the scrollbars should be vertical or horizontal.
-| invalidateAllCachedMeasurements    | `Function`        | `()=>void` - to force re-measuring *all* cached item sizes. If enableUnequalChildrenSizes===false, only 1 item will be re-measured.
+| invalidateAllCachedMeasurements    | `Function`        | `()=>void` - to force re-measuring *all* cached item sizes. If `enableUnequalChildrenSizes===false`, only 1 item will be re-measured.
 | invalidateCachedMeasurementAtIndex | `Function`        | `(index:number)=>void` - to force re-measuring cached item size.
 | invalidateCachedMeasurementForItem | `Function`        | `(item:any)=>void` - to force re-measuring cached item size.
-| items                              | any[]             | The data that builds the templates within the virtual scroll. This is the same data that you'd pass to ngFor. It's important to note that when this data has changed, then the entire virtual scroll is refreshed.
+| items                              | any[]             | The data that builds the templates within the virtual scroll. This is the same data that you'd pass to `ngFor`. It's important to note that when this data has changed, then the entire virtual scroll is refreshed.
 | modifyOverflowStyleOfParentScroll  | `boolean` true    | Set to false if you want to prevent ngx-virtual-scroller from automatically changing the overflow style setting of the parentScroll element to 'scroll'.
 | parentScroll                       | Element / Window  | Element (or window), which will have scrollbar. This element must be one of the parents of virtual-scroller
 | refresh                            | `Function`        | `()=>void` - to force re-rendering of current items in viewport.
-| RTL                                | `boolean` false   | Set to true if you want horizontal slider to support RTL.
+| RTL                                | `boolean` false   | Set to `true` if you want horizontal slider to support right to left script (RTL).
 | resizeBypassRefreshThreshold       | `number` 5        | How many pixels to ignore during resize check if virtual-scroller (or parentScroll) are only resized by a very small amount.
 | scrollAnimationTime                | `number` 750      | The time in milliseconds for the scroll animation to run for. 0 will completely disable the tween/animation.
 | scrollDebounceTime                 | `number` 0        | Milliseconds to delay refreshing viewport if user is scrolling quickly (for performance reasons).
@@ -189,10 +189,10 @@ interface IPageInfo {
 | scrollToPosition                   | `Function`        | `(scrollPosition:number, animationMilliseconds:number = undefined, animationCompletedCallback: ()=>void = undefined)=>void` - Scrolls to px position
 | scrollbarHeight                    | `number`          | If you want to override the auto-calculated scrollbar height. This is used to determine the dimensions of the viewable area when calculating the number of items to render.
 | scrollbarWidth                     | `number`          | If you want to override the auto-calculated scrollbar width. This is used to determine the dimensions of the viewable area when calculating the number of items to render.
-| ssrChildHeight                     | `number`          | The hard-coded height of the item template's cell to use if rendering via Angular Universal/Server-Side-Rendering
-| ssrChildWidth                      | `number`          | The hard-coded width of the item template's cell to use if rendering via Angular Universal/Server-Side-Rendering
-| ssrViewportHeight                  | `number` 1080     | The hard-coded visible height of the virtual-scroller (or [parentScroll]) to use if rendering via Angular Universal/Server-Side-Rendering.
-| ssrViewportWidth                   | `number` 1920     | The hard-coded visible width of the virtual-scroller (or [parentScroll]) to use if rendering via Angular Universal/Server-Side-Rendering.
+| ssrChildHeight                     | `number`          | The hard-coded height of the item template's cell to use if rendering via _Angular Universal/Server-Side-Rendering_
+| ssrChildWidth                      | `number`          | The hard-coded width of the item template's cell to use if rendering via _Angular Universal/Server-Side-Rendering_
+| ssrViewportHeight                  | `number` 1080     | The hard-coded visible height of the virtual-scroller (or [parentScroll]) to use if rendering via _Angular Universal/Server-Side-Rendering_.
+| ssrViewportWidth                   | `number` 1920     | The hard-coded visible width of the virtual-scroller (or [parentScroll]) to use if rendering via _Angular Universal/Server-Side-Rendering_.
 | stripedTable                       | `boolean` false   | Set to true if you use a striped table. In this case, the rows will be added/removed two by two to keep the strips consistent.
 | useMarginInsteadOfTranslate        | `boolean` false   | Translate is faster in many scenarios because it can use GPU acceleration, but it can be slower if your scroll container or child elements don't use any transitions or opacity. More importantly, translate creates a new "containing block" which breaks position:fixed because it'll be relative to the transform rather than the window. If you're experiencing issues with position:fixed on your child elements, turn this flag on.
 | viewPortInfo                       | `IPageInfo`       | Allows querying the the current viewport info on demand rather than listening for events.
@@ -201,8 +201,8 @@ interface IPageInfo {
 | vsEnd                              | Event<IPageInfo>  | This event is fired every time `end` index changes and emits `IPageInfo`.
 | vsStart                            | Event<IPageInfo>  | This event is fired every time `start` index changes and emits `IPageInfo`.
 | vsUpdate                           | Event<any[]>      | This event is fired every time the `start` or `end` indexes change and emits the list of items which should be visible based on the current scroll position from `start` to `end`. The list emitted by this event must be used with `*ngFor` to render the actual list of items within `<virtual-scroller>`
-| childHeight *(DEPRECATED)*         | `number`          | The minimum height of the item template's cell. Use this if enableUnequalChildrenSizes isn't working well enough. (The actual rendered size of the first cell is used by default if not specified.)
-| childWidth *(DEPRECATED)*          | `number`          | The minimum width of the item template's cell. Use this if enableUnequalChildrenSizes isn't working well enough. (The actual rendered size of the first cell is used by default if not specified.)
+| childHeight *(DEPRECATED)*         | `number`          | The minimum height of the item template's cell. Use this if `enableUnequalChildrenSizes` isn't working well enough. (The actual rendered size of the first cell is used by default if not specified.)
+| childWidth *(DEPRECATED)*          | `number`          | The minimum width of the item template's cell. Use this if `enableUnequalChildrenSizes` isn't working well enough. (The actual rendered size of the first cell is used by default if not specified.)
 
 Note: The Events without the "vs" prefix have been deprecated because they might conflict with native DOM events due to their "bubbling" nature. See https://github.com/angular/angular/issues/13997
 An example is if an <input> element inside <virtual-scroller> emits a "change" event which bubbles up to the (change) handler of virtual-scroller. Using the vs prefix will prevent this bubbling conflict because there are currently no official DOM events prefixed with vs.

--- a/README.md
+++ b/README.md
@@ -164,6 +164,8 @@ interface IPageInfo {
 
 ## API
 
+In _alphabetical_ order:
+
 | Attribute                          | `Type` & Default  | Description
 |------------------------------------|-------------------|--------------|
 | bufferAmount                       | `number` enableUnequalChildrenSizes ? 5 : 0 | The number of elements to be rendered above & below the current container's viewport. Increase this if `enableUnequalChildrenSizes` isn't working well enough.
@@ -482,14 +484,14 @@ sort() {
 ## Hide Scrollbar
 
 This hacky CSS allows hiding a scrollbar while still enabling scroll through mouseWheel/touch/pageUpDownKeys
-```css
-	//hide vertical scrollbar
-	   margin-right: -25px;
-	   padding-right: 25px;
+```scss
+    // hide vertical scrollbar
+    margin-right: -25px;
+    padding-right: 25px;
 
-	//hide horizontal scrollbar
-	   margin-bottom: -25px;
-	   padding-bottom: 25px;
+    // hide horizontal scrollbar
+    margin-bottom: -25px;
+    padding-bottom: 25px;
 ```
 
 ## Additional elements in scroll
@@ -509,10 +511,14 @@ If you want to nest additional elements inside virtual scroll besides the list i
 ## Performance - TrackBy
 
 virtual-scroller uses *ngFor to render the visible items. When an *ngFor array changes, Angular uses a trackBy function to determine if it should re-use or re-generate each component in the loop.
+
 For example, if 5 items are visible and scrolling causes 1 item to swap out but the other 4 remain visible, there's no reason Angular should re-generate those 4 components from scratch, it should reuse them.
+
 A trackBy function must return either a number or string as a unique identifier for your object.
-If the array used by *ngFor is of type number[] or string[], Angular's default trackBy function will work automatically, you don't need to do anything extra.
-If the array used by *ngFor is of type any[], you must code your own trackBy function.
+
+If the array used by *ngFor is of type `number[]` or `string[]`, Angular's default trackBy function will work automatically, you don't need to do anything extra.
+
+If the array used by *ngFor is of type `any[]`, you must code your own trackBy function.
 
 Here's an example of how to do this:
 
@@ -536,46 +542,48 @@ public myTrackByFunction(index: number, complexItem: IComplexItem): number {
 
 ## Performance - ChangeDetection
 
-virtual-scroller is coded to be extremely fast. If scrolling is slow in your app, the issue is with your custom component code, not with virtual-scroller itself.
+_virtual-scroller_ is coded to be extremely fast. If scrolling is slow in your app, the issue is with your custom component code, not with virtual-scroller itself.
 Below is an explanation of how to correct your code. This will make your entire app much faster, including virtual-scroller.
 
-Each component in Angular by default uses the ChangeDetectionStrategy.Default "CheckAlways" strategy. This means that Change Detection cycles will be running constantly which will check *EVERY* data-binding expression on *EVERY* component to see if anything has changed.
+Each component in Angular by default uses the `ChangeDetectionStrategy.Default` "CheckAlways" strategy. This means that Change Detection cycles will be running constantly which will check *EVERY* data-binding expression on *EVERY* component to see if anything has changed.
 This makes it easier for programmers to code apps, but also makes apps extremely slow.
 
-If virtual-scroller feels slow, a possible quick solution that masks the real problem is to use scrollThrottlingTime or scrollDebounceTime APIs.
+If virtual-scroller feels slow, a possible quick solution that masks the real problem is to use `scrollThrottlingTime` or `scrollDebounceTime` APIs.
 
-The correct fix is to make cycles as fast as possible and to avoid unnecessary ChangeDetection cycles. Cycles will be faster if you avoid complex logic in data-bindings. You can avoid unnecessary Cycles by converting your components to use ChangeDetectionStrategy.OnPush.
+The correct fix is to make cycles as fast as possible and to avoid unnecessary ChangeDetection cycles. Cycles will be faster if you avoid complex logic in data-bindings. You can avoid unnecessary Cycles by converting your components to use `ChangeDetectionStrategy.OnPush`.
 
-ChangeDetectionStrategy.OnPush means the consuming app is taking full responsibility for telling Angular when to run change detection rather than allowing Angular to figure it out itself. For example, virtual-scroller has a bound property [items]="myItems". If you use OnPush, you have to tell Angular when you change the myItems array, because it won't determine this automatically.
-OnPush is much harder for the programmer to code. You have to code things differently: This means 1) avoid mutating state on any bound properties where possible & 2) manually running change detection when you do mutate state.
+ChangeDetectionStrategy.OnPush means the consuming app is taking full responsibility for telling Angular when to run change detection rather than allowing Angular to figure it out itself. For example, virtual-scroller has a bound property `[items]="myItems"`. If you use OnPush, you have to tell Angular when you change the myItems array, because it won't determine this automatically.
+OnPush is much harder for the programmer to code. You have to code things differently: This means
+1) avoid mutating state on any bound properties where possible &
+2) manually running change detection when you do mutate state.
 OnPush can be done on a component-by-component basis, however I recommend doing it for *EVERY* component in your app.
 
-If your biggest priority is making virtual-scroller faster, the best candidates for OnPush will be all custom components being used as children underneath virtual-scroller. If you have a hierarchy of multiple custom components under virtual-scroller, ALL of them need to be converted to OnPush.
+If your biggest priority is making virtual-scroller faster, the best candidates for _OnPush_ will be all custom components being used as children underneath virtual-scroller. If you have a hierarchy of multiple custom components under virtual-scroller, ALL of them need to be converted to _OnPush_.
 
 My personal suggestion on the easiest way to implement OnPush across your entire app:
 ```ts
 import { ChangeDetectorRef } from '@angular/core';
 
 public class ManualChangeDetection {
-	public queueChangeDetection(): void {
-		this.changeDetectorRef.markForCheck(); // marks self for change detection on the next cycle, but doesn't actually schedule a cycle
-		this.queueApplicationTick();
-	}
+    public queueChangeDetection(): void {
+        this.changeDetectorRef.markForCheck(); // marks self for change detection on the next cycle, but doesn't actually schedule a cycle
+        this.queueApplicationTick();
+    }
 
-	public static STATIC_APPLICATION_REF: ApplicationRef;
-	public static queueApplicationTick: ()=> void = Util.debounce(() => {
-		if (ManualChangeDetection.STATIC_APPLICATION_REF['_runningTick']) {
-			return;
-		}
+    public static STATIC_APPLICATION_REF: ApplicationRef;
+    public static queueApplicationTick: ()=> void = Util.debounce(() => {
+        if (ManualChangeDetection.STATIC_APPLICATION_REF['_runningTick']) {
+            return;
+        }
 
-		ManualChangeDetection.STATIC_APPLICATION_REF.tick();
-	}, 5);
+        ManualChangeDetection.STATIC_APPLICATION_REF.tick();
+    }, 5);
 
-	constructor(private changeDetectorRef: ChangeDetectorRef) {
-	}
+    constructor(private changeDetectorRef: ChangeDetectorRef) {
+    }
 }
 
-//note: this portion is only needed if you don't already have a debounce implementation in your app
+// note: this portion is only needed if you don't already have a debounce implementation in your app
 public class Util {
     public static throttleTrailing(func: Function, wait: number): Function {
         let timeout = undefined;
@@ -623,9 +631,9 @@ public class Util {
 
 public class MyEntryLevelAppComponent
 {
-	constructor(applicationRef: ApplicationRef) {
-		ManualChangeDetection.STATIC_APPLICATION_REF = applicationRef;
-	}
+    constructor(applicationRef: ApplicationRef) {
+        ManualChangeDetection.STATIC_APPLICATION_REF = applicationRef;
+    }
 }
 
 @Component({
@@ -634,16 +642,16 @@ public class MyEntryLevelAppComponent
 	...
 })
 public class SomeRandomComponentWhichUsesOnPush {
-	private manualChangeDetection: ManualChangeDetection;
-	constructor(changeDetectorRef: ChangeDetectorRef) {
-		this.manualChangeDetection = new ManualChangeDetection(changeDetectorRef);
-	}
+    private manualChangeDetection: ManualChangeDetection;
+    constructor(changeDetectorRef: ChangeDetectorRef) {
+        this.manualChangeDetection = new ManualChangeDetection(changeDetectorRef);
+    }
 
-	public someFunctionThatMutatesState(): void {
-		this.someBoundProperty = someNewValue;
+    public someFunctionThatMutatesState(): void {
+        this.someBoundProperty = someNewValue;
 
-		this.manualChangeDetection.queueChangeDetection();
-	}
+        this.manualChangeDetection.queueChangeDetection();
+    }
 }
 ```
 The ManualChangeDetection/Util classes are helpers that can be copy/pasted directly into your app. The code for MyEntryLevelAppComponent & SomeRandomComponentWhichUsesOnPush are examples that you'll need to modify for your specific app. If you follow this pattern, OnPush is much easier to implement. However, the really hard part is analyzing all of your code to determine *where* you're mutating state. Unfortunately there's no magic bullet for this, you'll need to spend a lot of time reading/debugging/testing your code.
@@ -652,7 +660,7 @@ The ManualChangeDetection/Util classes are helpers that can be copy/pasted direc
 
 This API is meant as a quick band-aid fix for performance issues. Please read the other performance sections above to learn the ideal way to fix performance issues.
 
-ChangeDetectionStrategy.OnPush is the recommended strategy as it improves the entire app performance, not just virtual-scroller. However, ChangeDetectionStrategy.OnPush is hard to implement. executeRefreshOutsideAngularZone may be an easier initial approach until you're ready to tackle ChangeDetectionStrategy.OnPush.
+`ChangeDetectionStrategy.OnPush` is the recommended strategy as it improves the entire app performance, not just virtual-scroller. However, `ChangeDetectionStrategy.OnPush` is hard to implement. executeRefreshOutsideAngularZone may be an easier initial approach until you're ready to tackle `ChangeDetectionStrategy.OnPush`.
 
 If you've correctly implemented ChangeDetectionStrategy.OnPush for 100% of your components, the executeRefreshOutsideAngularZone will not provide any performance benefit.
 If you have not yet done this, scrolling may feel slow. This is because Angular performs a full-app change detection while scrolling. However, it's likely that only the components inside the scroller actually need the change detection to run, so a full-app change detection cycle is overkill.
@@ -673,29 +681,31 @@ public class MainComponent {
 </virtual-scroller>
 ```
 
-Note: executeRefreshOutsideAngularZone will disable Angular ChangeDetection during all virtual-scroller events, including: vsUpdate, vsStart, vsEnd, vsChange. If you change any data-bound properties inside these event handlers, you must perform manual change detection on those specific components. This can be done via changeDetectorRef.detectChanges() at the end of the event handler. Note: The changeDetectorRef is component-specific, so you'll need to inject it into a private variable in the constructor of the appropriate component before calling it in response to the virtual-scroller events.
+Note: `executeRefreshOutsideAngularZone` will disable Angular ChangeDetection during all virtual-scroller events, including: vsUpdate, vsStart, vsEnd, vsChange. If you change any data-bound properties inside these event handlers, you must perform manual change detection on those specific components. This can be done via changeDetectorRef.detectChanges() at the end of the event handler. Note: The changeDetectorRef is component-specific, so you'll need to inject it into a private variable in the constructor of the appropriate component before calling it in response to the virtual-scroller events.
 
 :warning: WARNING - Failure to perform manual change detection in response to _virtual-scroller_ events will cause your components to render a stale UI for a short time (until the next Change Detection cycle), which will make your app feel buggy.
 
-*Note* - changeDetectorRef.detectChanges() will execute change detection on the component and all its nested children. If multiple components need to run change detection in response to a virtual-scroller event, you can call detectChanges from a higher-level component in the ancestor hierarchy rather than on each individual component. However, its important to avoid too many extra change detection cycles by not going too high in the hierarchy unless all the nested children really need to have change detection performed.
+*Note* - `changeDetectorRef.detectChanges()` will execute change detection on the component and all its nested children. If multiple components need to run change detection in response to a virtual-scroller event, you can call detectChanges from a higher-level component in the ancestor hierarchy rather than on each individual component. However, its important to avoid too many extra change detection cycles by not going too high in the hierarchy unless all the nested children really need to have change detection performed.
 
 *Note* - All virtual-scroller events are emitted at the same time in response to its internal "refresh" function. Some of these event emitters are bypassed if certain criteria don't apply. however vsUpdate will always be emitted. For this reason, you should consolidate all data-bound property changes & manual change detection into the vsUpdate event handler, to avoid duplicate change detection cycles from executing during the other virtual-scroller events.
 
-In the above code example, (vsUpdate)="changeDetectorRef.detectChanges()" is necessary because scroll.viewPortItems was changed internally be virtual-scroller during its internal "render" function before emitting (vsUpdate). executeRefreshOutsideAngularZone prevents MainComponent from refreshing its data-binding in response to this change, so a manual Change Detection cycle must be run. No extra manual change detection code is necessary for virtual-scroller or my-custom-component, even if their data-bound properties have changed, because they're nested children of MainComponent.
+In the above code example, `(vsUpdate)="changeDetectorRef.detectChanges()"` is necessary because `scroll.viewPortItems` was changed internally be virtual-scroller during its internal "render" function before emitting (vsUpdate). `executeRefreshOutsideAngularZone` prevents _MainComponent_ from refreshing its data-binding in response to this change, so a manual Change Detection cycle must be run. No extra manual change detection code is necessary for virtual-scroller or my-custom-component, even if their data-bound properties have changed, because they're nested children of _MainComponent_.
 
 ## Performance - scrollDebounceTime / scrollThrottlingTime
 
 These APIs are meant as a quick band-aid fix for performance issues. Please read the other performance sections above to learn the ideal way to fix performance issues.
 
 Without these set, virtual-scroller will refresh immediately whenever the user scrolls.
-Throttle will delay refreshing until # milliseconds after scroll started. As the user continues to scroll, it will wait the same # milliseconds in between each successive refresh. Even if the user stops scrolling, it will still wait the allocated time before the final refresh.
-Debounce won't refresh until the user has stopped scrolling for # milliseconds.
+Throttle will delay refreshing until _# milliseconds_ after scroll started. As the user continues to scroll, it will wait the same _# milliseconds_ in between each successive refresh. Even if the user stops scrolling, it will still wait the allocated time before the final refresh.
+Debounce won't refresh until the user has stopped scrolling for _# milliseconds_.
 If both Debounce & Throttling are set, debounce takes precedence.
-Note: If virtual-scroller hasn't refreshed & the user has scrolled past bufferAmount, no child items will be rendered and virtual-scroller will appear blank. This may feel confusing to the user. You may want to have a spinner or loading message display when this occurs.
+
+*Note* - If virtual-scroller hasn't refreshed & the user has scrolled past bufferAmount, no child items will be rendered and virtual-scroller will appear blank. This may feel confusing to the user. You may want to have a spinner or loading message display when this occurs.
 
 ## Angular Universal / Server-Side Rendering
 
 The initial SSR render isn't a fully functioning site, it's essentially an HTML "screenshot" (HTML/CSS, but no JS). However, it immediately swaps out your "screenshot" with the real site as soon as the full app has downloaded in the background. The intent of SSR is to give a correct visual very quickly, because a full angular app could take a long time to download. This makes the user *think* your site is fast, because hopefully they won't click on anything that requires JS before the fully-functioning site has finished loading in the background. Also, it allows screen scrapers without javascript to work correctly (example: Facebook posts/etc).
+
 virtual-scroller relies on javascript APIs to measure the size of child elements and the scrollable area of their parent. These APIs do not work in SSR because the HTML/CSS "screenshot" is generated on the server via Node, it doesn't execute/render the site as a browser would. This means virtual-scroller will see all measurements as undefined and the "screenshot" will not be generated correctly. Most likely, only 1 child element will appear in your virtual-scroller. This "screenshot" can be fixed with polyfills. However, when the browser renders the "screenshot", the scrolling behaviour still won't work until the full app has loaded.
 
 SSR is an advanced (and complex) topic that can't be fully addressed here. Please research this on your own. However, here are some suggestions:
@@ -710,11 +720,17 @@ global['document'] = win.document;
 Object.defineProperty(win.document.body.style, 'transform', { value: () => { return { enumerable: true, configurable: true }; } });
 ```
 2) Determine a default screen size you want to use for the SSR "screenshot" calculations (suggestion: 1920x1080). This won't be accurate for all users, but will hopefully be close enough. Once the full Angular app loads in the background, their real device screensize will take over.
-3) Run your app in a real browser without SSR and determine the average width/height of the child elements inside virtual-scroller as well as the width/height of the virtual-scroller (or [parentScroll] element). Use these values to set the [ssrChildWidth]/[ssrChildHeight]/[ssrViewportWidth]/[ssrViewportHeight] properties.
+3) Run your app in a real browser without SSR and determine the average width/height of the child elements inside virtual-scroller as well as the width/height of the virtual-scroller (or `[parentScroll]` element). Use these values to set the `[ssrChildWidth]`/`[ssrChildHeight]`/`[ssrViewportWidth]`/`[ssrViewportHeight]` properties.
 ```html
 <virtual-scroller #scroll [items]="items">
 
-    <my-custom-component *ngFor="let item of scroll.viewPortItems" [ssrChildWidth]="138" [ssrChildHeight]="175" [ssrViewportWidth]="1500" [ssrViewportHeight]="800">
+    <my-custom-component
+        *ngFor="let item of scroll.viewPortItems"
+        [ssrChildWidth]="138"
+        [ssrChildHeight]="175"
+        [ssrViewportWidth]="1500"
+        [ssrViewportHeight]="800"
+    >
     </my-custom-component>
 
 </virtual-scroller>

--- a/README.md
+++ b/README.md
@@ -164,45 +164,45 @@ interface IPageInfo {
 
 ## API
 
-| Attribute                          | Type      | Description | Default
-|------------------------------------|-----------|-------------| -------
-| bufferAmount                       | number    | The number of elements to be rendered above & below the current container's viewport. Increase this if enableUnequalChildrenSizes isn't working well enough. | enableUnequalChildrenSizes ? 5 : 0
-| checkResizeInterval                | number    | How often in milliseconds to check if virtual-scroller (or parentScroll) has been resized. If resized, it'll call Refresh() method | 1000
-| compareItems                       | Function  | Predicate of syntax (item1:any, item2:any)=>boolean which is used when items array is modified to determine which items have been changed (determines if cached child size measurements need to be refreshed or not for enableUnequalChildrenSizes). | === comparison
-| enableUnequalChildrenSizes         | boolean   | If you want to use the "unequal size" children feature. This is not perfect, but hopefully "close-enough" for most situations. | false
-| executeRefreshOutsideAngularZone   | boolean   | Disables full-app Angular ChangeDetection while scrolling, which can give a performance boost. Requires developer to manually execute change detection on any components which may have changed. USE WITH CAUTION - Read the "Performance" section below. | false
-| horizontal                         | boolean   | Whether the scrollbars should be vertical or horizontal. | false
-| invalidateAllCachedMeasurements    | ()=>void  | Function to force re-measuring *all* cached item sizes. If enableUnequalChildrenSizes===false, only 1 item will be re-measured.
-| invalidateCachedMeasurementAtIndex | (index:number)=>void | Function to force re-measuring cached item size.
-| invalidateCachedMeasurementForItem | (item:any)=>void | Function to force re-measuring cached item size.
-| items                              | any[]     | The data that builds the templates within the virtual scroll. This is the same data that you'd pass to ngFor. It's important to note that when this data has changed, then the entire virtual scroll is refreshed.
-| modifyOverflowStyleOfParentScroll  | boolean   | Set to false if you want to prevent ngx-virtual-scroller from automatically changing the overflow style setting of the parentScroll element to 'scroll'. | true
-| parentScroll                       | Element / Window | Element (or window), which will have scrollbar. This element must be one of the parents of virtual-scroller
-| refresh                            | ()=>void  | Function to force re-rendering of current items in viewport.
-| RTL                                | boolean   | Set to true if you want horizontal slider to support RTL. | false
-| resizeBypassRefreshThreshold       | number    | How many pixels to ignore during resize check if virtual-scroller (or parentScroll) are only resized by a very small amount. | 5
-| scrollAnimationTime                | number    | The time in milliseconds for the scroll animation to run for. 0 will completely disable the tween/animation. | 750
-| scrollDebounceTime                 | number    | Milliseconds to delay refreshing viewport if user is scrolling quickly (for performance reasons). | 0
-| scrollInto                         | (item:any, alignToBeginning:boolean = true, additionalOffset:number = 0, animationMilliseconds:number = undefined, animationCompletedCallback:()=>void = undefined)=>void | Scrolls to item
-| scrollThrottlingTime               | number    | Milliseconds to delay refreshing viewport if user is scrolling quickly (for performance reasons). | 0
-| scrollToIndex                      | (index:number, alignToBeginning:boolean = true, additionalOffset:number = 0, animationMilliseconds:number = undefined, animationCompletedCallback:()=>void = undefined)=>void | Scrolls to item at index
-| scrollToPosition                   | (scrollPosition:number, animationMilliseconds:number = undefined, animationCompletedCallback: ()=>void = undefined)=>void | Scrolls to px position
-| scrollbarHeight                    | number    | If you want to override the auto-calculated scrollbar height. This is used to determine the dimensions of the viewable area when calculating the number of items to render.
-| scrollbarWidth                     | number    | If you want to override the auto-calculated scrollbar width. This is used to determine the dimensions of the viewable area when calculating the number of items to render.
-| ssrChildHeight                     | number    | The hard-coded height of the item template's cell to use if rendering via Angular Universal/Server-Side-Rendering
-| ssrChildWidth                      | number    | The hard-coded width of the item template's cell to use if rendering via Angular Universal/Server-Side-Rendering
-| ssrViewportHeight                  | number    | The hard-coded visible height of the virtual-scroller (or [parentScroll]) to use if rendering via Angular Universal/Server-Side-Rendering. | 1080
-| ssrViewportWidth                   | number    | The hard-coded visible width of the virtual-scroller (or [parentScroll]) to use if rendering via Angular Universal/Server-Side-Rendering. | 1920
-| stripedTable                       | boolean   | Set to true if you use a striped table. In this case, the rows will be added/removed two by two to keep the strips consistent. | false
-| useMarginInsteadOfTranslate        | boolean   | Translate is faster in many scenarios because it can use GPU acceleration, but it can be slower if your scroll container or child elements don't use any transitions or opacity. More importantly, translate creates a new "containing block" which breaks position:fixed because it'll be relative to the transform rather than the window. If you're experiencing issues with position:fixed on your child elements, turn this flag on. | false
-| viewPortInfo                       | IPageInfo | Allows querying the the current viewport info on demand rather than listening for events.
-| viewPortItems                      | any[] | The array of items currently being rendered to the viewport.
-| vsChange                           | Event<IPageInfo> | This event is fired every time the `start` or `end` indexes or scroll position change and emits `IPageInfo`.
-| vsEnd                              | Event<IPageInfo> | This event is fired every time `end` index changes and emits `IPageInfo`.
-| vsStart                            | Event<IPageInfo> | This event is fired every time `start` index changes and emits `IPageInfo`.
-| vsUpdate                           | Event<any[]> | This event is fired every time the `start` or `end` indexes change and emits the list of items which should be visible based on the current scroll position from `start` to `end`. The list emitted by this event must be used with `*ngFor` to render the actual list of items within `<virtual-scroller>`
-| childHeight (DEPRECATED)           | number    | The minimum height of the item template's cell. Use this if enableUnequalChildrenSizes isn't working well enough. (The actual rendered size of the first cell is used by default if not specified.)
-| childWidth (DEPRECATED)            | number    | The minimum width of the item template's cell. Use this if enableUnequalChildrenSizes isn't working well enough. (The actual rendered size of the first cell is used by default if not specified.)
+| Attribute                          | `Type` & Default  | Description
+|------------------------------------|-------------------|--------------|
+| bufferAmount                       | `number` enableUnequalChildrenSizes ? 5 : 0 | The number of elements to be rendered above & below the current container's viewport. Increase this if enableUnequalChildrenSizes isn't working well enough.
+| checkResizeInterval                | `number` 1000     | How often in milliseconds to check if virtual-scroller (or parentScroll) has been resized. If resized, it'll call Refresh() method
+| compareItems                       | `Function` === comparison | Predicate of syntax (item1:any, item2:any)=>boolean which is used when items array is modified to determine which items have been changed (determines if cached child size measurements need to be refreshed or not for enableUnequalChildrenSizes).
+| enableUnequalChildrenSizes         | `boolean` false   | If you want to use the "unequal size" children feature. This is not perfect, but hopefully "close-enough" for most situations.
+| executeRefreshOutsideAngularZone   | `boolean` false   | Disables full-app Angular ChangeDetection while scrolling, which can give a performance boost. Requires developer to manually execute change detection on any components which may have changed. USE WITH CAUTION - Read the "Performance" section below.
+| horizontal                         | `boolean` false   | Whether the scrollbars should be vertical or horizontal.
+| invalidateAllCachedMeasurements    | `Function`        | `()=>void` - to force re-measuring *all* cached item sizes. If enableUnequalChildrenSizes===false, only 1 item will be re-measured.
+| invalidateCachedMeasurementAtIndex | `Function`        | `(index:number)=>void` - to force re-measuring cached item size.
+| invalidateCachedMeasurementForItem | `Function`        | `(item:any)=>void` - to force re-measuring cached item size.
+| items                              | any[]             | The data that builds the templates within the virtual scroll. This is the same data that you'd pass to ngFor. It's important to note that when this data has changed, then the entire virtual scroll is refreshed.
+| modifyOverflowStyleOfParentScroll  | `boolean` true    | Set to false if you want to prevent ngx-virtual-scroller from automatically changing the overflow style setting of the parentScroll element to 'scroll'.
+| parentScroll                       | Element / Window  | Element (or window), which will have scrollbar. This element must be one of the parents of virtual-scroller
+| refresh                            | `Function`        | `()=>void` - to force re-rendering of current items in viewport.
+| RTL                                | `boolean` false   | Set to true if you want horizontal slider to support RTL.
+| resizeBypassRefreshThreshold       | `number` 5        | How many pixels to ignore during resize check if virtual-scroller (or parentScroll) are only resized by a very small amount.
+| scrollAnimationTime                | `number` 750      | The time in milliseconds for the scroll animation to run for. 0 will completely disable the tween/animation.
+| scrollDebounceTime                 | `number` 0        | Milliseconds to delay refreshing viewport if user is scrolling quickly (for performance reasons).
+| scrollInto                         | `Function`        | `(item:any, alignToBeginning:boolean = true, additionalOffset:number = 0, animationMilliseconds:number = undefined, animationCompletedCallback:()=>void = undefined)=>void` - Scrolls to item
+| scrollThrottlingTime               | `number` 0        | Milliseconds to delay refreshing viewport if user is scrolling quickly (for performance reasons).
+| scrollToIndex                      | `Function`        | `(index:number, alignToBeginning:boolean = true, additionalOffset:number = 0, animationMilliseconds:number = undefined, animationCompletedCallback:()=>void = undefined)=>void` - Scrolls to item at index
+| scrollToPosition                   | `Function`        | `(scrollPosition:number, animationMilliseconds:number = undefined, animationCompletedCallback: ()=>void = undefined)=>void` - Scrolls to px position
+| scrollbarHeight                    | `number`          | If you want to override the auto-calculated scrollbar height. This is used to determine the dimensions of the viewable area when calculating the number of items to render.
+| scrollbarWidth                     | `number`          | If you want to override the auto-calculated scrollbar width. This is used to determine the dimensions of the viewable area when calculating the number of items to render.
+| ssrChildHeight                     | `number`          | The hard-coded height of the item template's cell to use if rendering via Angular Universal/Server-Side-Rendering
+| ssrChildWidth                      | `number`          | The hard-coded width of the item template's cell to use if rendering via Angular Universal/Server-Side-Rendering
+| ssrViewportHeight                  | `number` 1080     | The hard-coded visible height of the virtual-scroller (or [parentScroll]) to use if rendering via Angular Universal/Server-Side-Rendering.
+| ssrViewportWidth                   | `number` 1920     | The hard-coded visible width of the virtual-scroller (or [parentScroll]) to use if rendering via Angular Universal/Server-Side-Rendering.
+| stripedTable                       | `boolean` false   | Set to true if you use a striped table. In this case, the rows will be added/removed two by two to keep the strips consistent.
+| useMarginInsteadOfTranslate        | `boolean` false   | Translate is faster in many scenarios because it can use GPU acceleration, but it can be slower if your scroll container or child elements don't use any transitions or opacity. More importantly, translate creates a new "containing block" which breaks position:fixed because it'll be relative to the transform rather than the window. If you're experiencing issues with position:fixed on your child elements, turn this flag on.
+| viewPortInfo                       | `IPageInfo`       | Allows querying the the current viewport info on demand rather than listening for events.
+| viewPortItems                      | any[]             | The array of items currently being rendered to the viewport.
+| vsChange                           | Event<IPageInfo>  | This event is fired every time the `start` or `end` indexes or scroll position change and emits `IPageInfo`.
+| vsEnd                              | Event<IPageInfo>  | This event is fired every time `end` index changes and emits `IPageInfo`.
+| vsStart                            | Event<IPageInfo>  | This event is fired every time `start` index changes and emits `IPageInfo`.
+| vsUpdate                           | Event<any[]>      | This event is fired every time the `start` or `end` indexes change and emits the list of items which should be visible based on the current scroll position from `start` to `end`. The list emitted by this event must be used with `*ngFor` to render the actual list of items within `<virtual-scroller>`
+| childHeight *(DEPRECATED)*         | `number`          | The minimum height of the item template's cell. Use this if enableUnequalChildrenSizes isn't working well enough. (The actual rendered size of the first cell is used by default if not specified.)
+| childWidth *(DEPRECATED)*          | `number`          | The minimum width of the item template's cell. Use this if enableUnequalChildrenSizes isn't working well enough. (The actual rendered size of the first cell is used by default if not specified.)
 
 Note: The Events without the "vs" prefix have been deprecated because they might conflict with native DOM events due to their "bubbling" nature. See https://github.com/angular/angular/issues/13997
 An example is if an <input> element inside <virtual-scroller> emits a "change" event which bubbles up to the (change) handler of virtual-scroller. Using the vs prefix will prevent this bubbling conflict because there are currently no official DOM events prefixed with vs.

--- a/README.md
+++ b/README.md
@@ -164,45 +164,45 @@ interface IPageInfo {
 
 ## API
 
-| Attribute      | Type   | Description | Default
-|----------------|--------|-------------| -------
-| bufferAmount | number | The number of elements to be rendered above & below the current container's viewport. Increase this if enableUnequalChildrenSizes isn't working well enough. | enableUnequalChildrenSizes ? 5 : 0
-| checkResizeInterval | number | How often in milliseconds to check if virtual-scroller (or parentScroll) has been resized. If resized, it'll call Refresh() method | 1000
-| compareItems   | Function | Predicate of syntax (item1:any, item2:any)=>boolean which is used when items array is modified to determine which items have been changed (determines if cached child size measurements need to be refreshed or not for enableUnequalChildrenSizes). | === comparison
-| enableUnequalChildrenSizes | boolean | If you want to use the "unequal size" children feature. This is not perfect, but hopefully "close-enough" for most situations. | false
-| executeRefreshOutsideAngularZone | boolean | Disables full-app Angular ChangeDetection while scrolling, which can give a performance boost. Requires developer to manually execute change detection on any components which may have changed. USE WITH CAUTION - Read the "Performance" section below. | false
-| horizontal | boolean | Whether the scrollbars should be vertical or horizontal. | false
-| invalidateAllCachedMeasurements | ()=>void | Function to force re-measuring *all* cached item sizes. If enableUnequalChildrenSizes===false, only 1 item will be re-measured.
+| Attribute                          | Type      | Description | Default
+|------------------------------------|-----------|-------------| -------
+| bufferAmount                       | number    | The number of elements to be rendered above & below the current container's viewport. Increase this if enableUnequalChildrenSizes isn't working well enough. | enableUnequalChildrenSizes ? 5 : 0
+| checkResizeInterval                | number    | How often in milliseconds to check if virtual-scroller (or parentScroll) has been resized. If resized, it'll call Refresh() method | 1000
+| compareItems                       | Function  | Predicate of syntax (item1:any, item2:any)=>boolean which is used when items array is modified to determine which items have been changed (determines if cached child size measurements need to be refreshed or not for enableUnequalChildrenSizes). | === comparison
+| enableUnequalChildrenSizes         | boolean   | If you want to use the "unequal size" children feature. This is not perfect, but hopefully "close-enough" for most situations. | false
+| executeRefreshOutsideAngularZone   | boolean   | Disables full-app Angular ChangeDetection while scrolling, which can give a performance boost. Requires developer to manually execute change detection on any components which may have changed. USE WITH CAUTION - Read the "Performance" section below. | false
+| horizontal                         | boolean   | Whether the scrollbars should be vertical or horizontal. | false
+| invalidateAllCachedMeasurements    | ()=>void  | Function to force re-measuring *all* cached item sizes. If enableUnequalChildrenSizes===false, only 1 item will be re-measured.
 | invalidateCachedMeasurementAtIndex | (index:number)=>void | Function to force re-measuring cached item size.
 | invalidateCachedMeasurementForItem | (item:any)=>void | Function to force re-measuring cached item size.
-| items          | any[]  | The data that builds the templates within the virtual scroll. This is the same data that you'd pass to ngFor. It's important to note that when this data has changed, then the entire virtual scroll is refreshed.
-| modifyOverflowStyleOfParentScroll | boolean | Set to false if you want to prevent ngx-virtual-scroller from automatically changing the overflow style setting of the parentScroll element to 'scroll'. | true
-| parentScroll   | Element / Window | Element (or window), which will have scrollbar. This element must be one of the parents of virtual-scroller
-| refresh | ()=>void | Function to force re-rendering of current items in viewport.
-| RTL | boolean | Set to true if you want horizontal slider to support RTL. | false
-| resizeBypassRefreshThreshold | number | How many pixels to ignore during resize check if virtual-scroller (or parentScroll) are only resized by a very small amount. | 5
-| scrollAnimationTime | number | The time in milliseconds for the scroll animation to run for. 0 will completely disable the tween/animation. | 750
-| scrollDebounceTime | number | Milliseconds to delay refreshing viewport if user is scrolling quickly (for performance reasons). | 0
-| scrollInto | (item:any, alignToBeginning:boolean = true, additionalOffset:number = 0, animationMilliseconds:number = undefined, animationCompletedCallback:()=>void = undefined)=>void | Scrolls to item
-| scrollThrottlingTime | number | Milliseconds to delay refreshing viewport if user is scrolling quickly (for performance reasons). | 0
-| scrollToIndex | (index:number, alignToBeginning:boolean = true, additionalOffset:number = 0, animationMilliseconds:number = undefined, animationCompletedCallback:()=>void = undefined)=>void | Scrolls to item at index
-| scrollToPosition | (scrollPosition:number, animationMilliseconds:number = undefined, animationCompletedCallback: ()=>void = undefined)=>void | Scrolls to px position
-| scrollbarHeight | number | If you want to override the auto-calculated scrollbar height. This is used to determine the dimensions of the viewable area when calculating the number of items to render.
-| scrollbarWidth | number | If you want to override the auto-calculated scrollbar width. This is used to determine the dimensions of the viewable area when calculating the number of items to render.
-| ssrChildHeight | number | The hard-coded height of the item template's cell to use if rendering via Angular Universal/Server-Side-Rendering
-| ssrChildWidth | number | The hard-coded width of the item template's cell to use if rendering via Angular Universal/Server-Side-Rendering
-| ssrViewportHeight | number | The hard-coded visible height of the virtual-scroller (or [parentScroll]) to use if rendering via Angular Universal/Server-Side-Rendering. | 1080
-| ssrViewportWidth | number | The hard-coded visible width of the virtual-scroller (or [parentScroll]) to use if rendering via Angular Universal/Server-Side-Rendering. | 1920
-| stripedTable          | boolean  | Set to true if you use a striped table. In this case, the rows will be added/removed two by two to keep the strips consistent. | false
-| useMarginInsteadOfTranslate | boolean | Translate is faster in many scenarios because it can use GPU acceleration, but it can be slower if your scroll container or child elements don't use any transitions or opacity. More importantly, translate creates a new "containing block" which breaks position:fixed because it'll be relative to the transform rather than the window. If you're experiencing issues with position:fixed on your child elements, turn this flag on. | false
-| viewPortInfo | IPageInfo | Allows querying the the current viewport info on demand rather than listening for events.
-| viewPortItems | any[] | The array of items currently being rendered to the viewport.
-| vsChange         | Event<IPageInfo>  | This event is fired every time the `start` or `end` indexes or scroll position change and emits `IPageInfo`.
-| vsEnd         | Event<IPageInfo>  | This event is fired every time `end` index changes and emits `IPageInfo`.
-| vsStart         | Event<IPageInfo>  | This event is fired every time `start` index changes and emits `IPageInfo`.
-| vsUpdate         | Event<any[]>  | This event is fired every time the `start` or `end` indexes change and emits the list of items which should be visible based on the current scroll position from `start` to `end`. The list emitted by this event must be used with `*ngFor` to render the actual list of items within `<virtual-scroller>`
-| childHeight (DEPRECATED)    | number | The minimum height of the item template's cell. Use this if enableUnequalChildrenSizes isn't working well enough. (The actual rendered size of the first cell is used by default if not specified.)
-| childWidth (DEPRECATED)     | number | The minimum width of the item template's cell. Use this if enableUnequalChildrenSizes isn't working well enough. (The actual rendered size of the first cell is used by default if not specified.)
+| items                              | any[]     | The data that builds the templates within the virtual scroll. This is the same data that you'd pass to ngFor. It's important to note that when this data has changed, then the entire virtual scroll is refreshed.
+| modifyOverflowStyleOfParentScroll  | boolean   | Set to false if you want to prevent ngx-virtual-scroller from automatically changing the overflow style setting of the parentScroll element to 'scroll'. | true
+| parentScroll                       | Element / Window | Element (or window), which will have scrollbar. This element must be one of the parents of virtual-scroller
+| refresh                            | ()=>void  | Function to force re-rendering of current items in viewport.
+| RTL                                | boolean   | Set to true if you want horizontal slider to support RTL. | false
+| resizeBypassRefreshThreshold       | number    | How many pixels to ignore during resize check if virtual-scroller (or parentScroll) are only resized by a very small amount. | 5
+| scrollAnimationTime                | number    | The time in milliseconds for the scroll animation to run for. 0 will completely disable the tween/animation. | 750
+| scrollDebounceTime                 | number    | Milliseconds to delay refreshing viewport if user is scrolling quickly (for performance reasons). | 0
+| scrollInto                         | (item:any, alignToBeginning:boolean = true, additionalOffset:number = 0, animationMilliseconds:number = undefined, animationCompletedCallback:()=>void = undefined)=>void | Scrolls to item
+| scrollThrottlingTime               | number    | Milliseconds to delay refreshing viewport if user is scrolling quickly (for performance reasons). | 0
+| scrollToIndex                      | (index:number, alignToBeginning:boolean = true, additionalOffset:number = 0, animationMilliseconds:number = undefined, animationCompletedCallback:()=>void = undefined)=>void | Scrolls to item at index
+| scrollToPosition                   | (scrollPosition:number, animationMilliseconds:number = undefined, animationCompletedCallback: ()=>void = undefined)=>void | Scrolls to px position
+| scrollbarHeight                    | number    | If you want to override the auto-calculated scrollbar height. This is used to determine the dimensions of the viewable area when calculating the number of items to render.
+| scrollbarWidth                     | number    | If you want to override the auto-calculated scrollbar width. This is used to determine the dimensions of the viewable area when calculating the number of items to render.
+| ssrChildHeight                     | number    | The hard-coded height of the item template's cell to use if rendering via Angular Universal/Server-Side-Rendering
+| ssrChildWidth                      | number    | The hard-coded width of the item template's cell to use if rendering via Angular Universal/Server-Side-Rendering
+| ssrViewportHeight                  | number    | The hard-coded visible height of the virtual-scroller (or [parentScroll]) to use if rendering via Angular Universal/Server-Side-Rendering. | 1080
+| ssrViewportWidth                   | number    | The hard-coded visible width of the virtual-scroller (or [parentScroll]) to use if rendering via Angular Universal/Server-Side-Rendering. | 1920
+| stripedTable                       | boolean   | Set to true if you use a striped table. In this case, the rows will be added/removed two by two to keep the strips consistent. | false
+| useMarginInsteadOfTranslate        | boolean   | Translate is faster in many scenarios because it can use GPU acceleration, but it can be slower if your scroll container or child elements don't use any transitions or opacity. More importantly, translate creates a new "containing block" which breaks position:fixed because it'll be relative to the transform rather than the window. If you're experiencing issues with position:fixed on your child elements, turn this flag on. | false
+| viewPortInfo                       | IPageInfo | Allows querying the the current viewport info on demand rather than listening for events.
+| viewPortItems                      | any[] | The array of items currently being rendered to the viewport.
+| vsChange                           | Event<IPageInfo> | This event is fired every time the `start` or `end` indexes or scroll position change and emits `IPageInfo`.
+| vsEnd                              | Event<IPageInfo> | This event is fired every time `end` index changes and emits `IPageInfo`.
+| vsStart                            | Event<IPageInfo> | This event is fired every time `start` index changes and emits `IPageInfo`.
+| vsUpdate                           | Event<any[]> | This event is fired every time the `start` or `end` indexes change and emits the list of items which should be visible based on the current scroll position from `start` to `end`. The list emitted by this event must be used with `*ngFor` to render the actual list of items within `<virtual-scroller>`
+| childHeight (DEPRECATED)           | number    | The minimum height of the item template's cell. Use this if enableUnequalChildrenSizes isn't working well enough. (The actual rendered size of the first cell is used by default if not specified.)
+| childWidth (DEPRECATED)            | number    | The minimum width of the item template's cell. Use this if enableUnequalChildrenSizes isn't working well enough. (The actual rendered size of the first cell is used by default if not specified.)
 
 Note: The Events without the "vs" prefix have been deprecated because they might conflict with native DOM events due to their "bubbling" nature. See https://github.com/angular/angular/issues/13997
 An example is if an <input> element inside <virtual-scroller> emits a "change" event which bubbles up to the (change) handler of virtual-scroller. Using the vs prefix will prevent this bubbling conflict because there are currently no official DOM events prefixed with vs.

--- a/README.md
+++ b/README.md
@@ -726,7 +726,7 @@ The initial SSR render isn't a fully functioning site, it's essentially an HTML 
 virtual-scroller relies on JavasSript APIs to measure the size of child elements and the scrollable area of their parent. These APIs do not work in SSR because the HTML/CSS "screenshot" is generated on the server via Node, it doesn't execute/render the site as a browser would. This means _virtual-scroller_ will see all measurements as undefined and the "screenshot" will not be generated correctly. Most likely, only 1 child element will appear in your _virtual-scroller_. This "screenshot" can be fixed with polyfills. However, when the browser renders the "screenshot", the scrolling behaviour still won't work until the full app has loaded.
 
 SSR is an advanced (and complex) topic that can't be fully addressed here. Please research this on your own. However, here are some suggestions:
-1) Use https://www.npmjs.com/package/domino and https://www.npmjs.com/package/raf polyfills in your main.server.ts file
+1) Use https://www.npmjs.com/package/domino and https://www.npmjs.com/package/raf polyfills in your `main.server.ts` file
 ```ts
 const domino = require('domino');
 require('raf/polyfill');
@@ -754,7 +754,7 @@ Object.defineProperty(win.document.body.style, 'transform', { value: () => { ret
 ```
 
 ## Known Issues
-The following are known issues that we don't know how to solve or don't have the resources to do so. Please don't submit a ticket for them. If you have an idea on how to fix them, please submit a pull request :)
+The following are known issues that we don't know how to solve or don't have the resources to do so. Please don't submit a ticket for them. If you have an idea on how to fix them, please submit a pull request :slightly_smiling_face:
 
 ### Nested Scrollbars
 If there are 2 nested scrollbars on the page the mouse scrollwheel will only affect the scrollbar of the nearest parent to the current mouse position. This means if you scroll to the bottom of a _virtual-scroller_ using the mousewheel & the window has an extra scrollbar, you cannot use the scrollwheel to scroll the page unless you move the mouse pointer out of the _virtual-scroller_ element.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-virtual-scroller",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build:all": "npm run build && npm run build:docs",
     "lint": "tslint src/**/*.ts",
     "debug-demo": "npm run build:all && cd demo && npm run start",
-    "test": "npm test",
+    "test": "echo \"Not implemented\" && exit 1",
     "ngc": "ngc",
     "update-npm-versions": "npm-check --skip-unused --update-all --save-exact --ignore typescript --ignore @tweenjs/tween.js --ignore @types/tween.js",
     "prepublishOnly": "PLEASE RUN \"npm run prod-publish\" NOT \"npm publish\"",

--- a/src/virtual-scroller.ts
+++ b/src/virtual-scroller.ts
@@ -1,21 +1,20 @@
 import {
+	ChangeDetectorRef,
 	Component,
 	ContentChild,
 	ElementRef,
 	EventEmitter,
 	Inject,
-	Optional,
 	Input,
 	NgModule,
 	NgZone,
 	OnChanges,
 	OnDestroy,
 	OnInit,
+	Optional,
 	Output,
 	Renderer2,
 	ViewChild,
-	ChangeDetectorRef,
-	InjectionToken
 } from '@angular/core';
 
 import { PLATFORM_ID } from '@angular/core';
@@ -26,63 +25,63 @@ import { CommonModule } from '@angular/common';
 import * as tween from '@tweenjs/tween.js'
 
 export interface VirtualScrollerDefaultOptions {
-	scrollThrottlingTime: number;
-	scrollDebounceTime: number;
-	scrollAnimationTime: number;
-	scrollbarWidth?: number;
-	scrollbarHeight?: number;
 	checkResizeInterval: number
-	resizeBypassRefreshThreshold: number,
 	modifyOverflowStyleOfParentScroll: boolean,
+	resizeBypassRefreshThreshold: number,
+	scrollAnimationTime: number;
+	scrollDebounceTime: number;
+	scrollThrottlingTime: number;
+	scrollbarHeight?: number;
+	scrollbarWidth?: number;
 	stripedTable: boolean
 }
 
 export function VIRTUAL_SCROLLER_DEFAULT_OPTIONS_FACTORY(): VirtualScrollerDefaultOptions {
 	return {
-		scrollThrottlingTime: 0,
-		scrollDebounceTime: 0,
-		scrollAnimationTime: 750,
 		checkResizeInterval: 1000,
-		resizeBypassRefreshThreshold: 5,
 		modifyOverflowStyleOfParentScroll: true,
+		resizeBypassRefreshThreshold: 5,
+		scrollAnimationTime: 750,
+		scrollDebounceTime: 0,
+		scrollThrottlingTime: 0,
 		stripedTable: false
 	};
 }
 
 export interface WrapGroupDimensions {
-	numberOfKnownWrapGroupChildSizes: number;
-	sumOfKnownWrapGroupChildWidths: number;
-	sumOfKnownWrapGroupChildHeights: number;
 	maxChildSizePerWrapGroup: WrapGroupDimension[];
+	numberOfKnownWrapGroupChildSizes: number;
+	sumOfKnownWrapGroupChildHeights: number;
+	sumOfKnownWrapGroupChildWidths: number;
 }
 
 export interface WrapGroupDimension {
-	childWidth: number;
 	childHeight: number;
+	childWidth: number;
 	items: any[];
 }
 
 export interface IDimensions {
-	itemCount: number;
-	itemsPerWrapGroup: number;
-	wrapGroupsPerPage: number;
-	itemsPerPage: number;
-	pageCount_fractional: number;
-	childWidth: number;
 	childHeight: number;
+	childWidth: number;
+	itemCount: number;
+	itemsPerPage: number;
+	itemsPerWrapGroup: number;
+	maxScrollPosition: number;
+	pageCount_fractional: number;
 	scrollLength: number;
 	viewportLength: number;
-	maxScrollPosition: number;
+	wrapGroupsPerPage: number;
 }
 
 export interface IPageInfo {
-	startIndex: number;
 	endIndex: number;
-	scrollStartPosition: number;
-	scrollEndPosition: number;
-	startIndexWithBuffer: number;
 	endIndexWithBuffer: number;
 	maxScrollPosition: number;
+	scrollEndPosition: number;
+	scrollStartPosition: number;
+	startIndex: number;
+	startIndexWithBuffer: number;
 }
 
 export interface IViewport extends IPageInfo {
@@ -108,23 +107,23 @@ export interface IViewport extends IPageInfo {
 	styles: [`
     :host {
       position: relative;
-	  display: block;
+	  	display: block;
       -webkit-overflow-scrolling: touch;
     }
 
-	:host.horizontal.selfScroll {
+		:host.horizontal.selfScroll {
       overflow-y: visible;
       overflow-x: auto;
-	}
-	
-	:host.horizontal.selfScroll.rtl {
-		transform: scaleX(-1);
-	}
+		}
 
-	:host.vertical.selfScroll {
+		:host.horizontal.selfScroll.rtl {
+			transform: scaleX(-1);
+		}
+
+		:host.vertical.selfScroll {
       overflow-y: auto;
       overflow-x: visible;
-	}
+		}
 
     .scrollable-content {
       top: 0;
@@ -136,28 +135,28 @@ export interface IViewport extends IPageInfo {
       position: absolute;
     }
 
-	.scrollable-content ::ng-deep > * {
-		box-sizing: border-box;
-	}
+		.scrollable-content ::ng-deep > * {
+			box-sizing: border-box;
+		}
 
-	:host.horizontal {
-		white-space: nowrap;
-	}
+		:host.horizontal {
+			white-space: nowrap;
+		}
 
-	:host.horizontal .scrollable-content {
-		display: flex;
-	}
+		:host.horizontal .scrollable-content {
+			display: flex;
+		}
 
-	:host.horizontal .scrollable-content ::ng-deep > * {
-		flex-shrink: 0;
-		flex-grow: 0;
-		white-space: initial;
-	}
+		:host.horizontal .scrollable-content ::ng-deep > * {
+			flex-shrink: 0;
+			flex-grow: 0;
+			white-space: initial;
+		}
 
-	:host.horizontal.rtl .scrollable-content  ::ng-deep > * {
-		transform:scaleX(-1);
-	}
-	
+		:host.horizontal.rtl .scrollable-content ::ng-deep > * {
+			transform:scaleX(-1);
+		}
+
     .total-padding {
       width: 1px;
       opacity: 0;
@@ -202,9 +201,10 @@ export class VirtualScrollerComponent implements OnInit, OnChanges, OnDestroy {
 		this.minMeasuredChildWidth = undefined;
 		this.minMeasuredChildHeight = undefined;
 	}
+
 	@Input()
 	public RTL: boolean = false;
-	
+
 	@Input()
 	public useMarginInsteadOfTranslate: boolean = false;
 
@@ -412,7 +412,6 @@ export class VirtualScrollerComponent implements OnInit, OnChanges, OnDestroy {
 		this.refresh_internal(indexLengthChanged || firstRun);
 	}
 
-
 	public ngDoCheck(): void {
 		if (this.cachedItemsLength !== this.items.length) {
 			this.cachedItemsLength = this.items.length;
@@ -545,7 +544,7 @@ export class VirtualScrollerComponent implements OnInit, OnChanges, OnDestroy {
 			this.currentTween = undefined;
 		}
 
-		if (!animationMilliseconds) {
+		if (animationMilliseconds === 0) {
 			this.renderer.setProperty(scrollElement, this._scrollType, scrollPosition);
 			this.refresh_internal(false, animationCompletedCallback);
 			return;
@@ -590,24 +589,26 @@ export class VirtualScrollerComponent implements OnInit, OnChanges, OnDestroy {
 
 	protected isAngularUniversalSSR: boolean;
 
-	constructor(protected readonly element: ElementRef,
+	constructor(
+		protected readonly element: ElementRef,
 		protected readonly renderer: Renderer2,
 		protected readonly zone: NgZone,
 		protected changeDetectorRef: ChangeDetectorRef,
 		@Inject(PLATFORM_ID) platformId: Object,
 		@Optional() @Inject('virtual-scroller-default-options')
-		options: VirtualScrollerDefaultOptions) {
+		options: VirtualScrollerDefaultOptions
+	) {
 
 		this.isAngularUniversalSSR = isPlatformServer(platformId);
 
-		this.scrollThrottlingTime = options.scrollThrottlingTime;
-		this.scrollDebounceTime = options.scrollDebounceTime;
-		this.scrollAnimationTime = options.scrollAnimationTime;
-		this.scrollbarWidth = options.scrollbarWidth;
-		this.scrollbarHeight = options.scrollbarHeight;
 		this.checkResizeInterval = options.checkResizeInterval;
-		this.resizeBypassRefreshThreshold = options.resizeBypassRefreshThreshold;
 		this.modifyOverflowStyleOfParentScroll = options.modifyOverflowStyleOfParentScroll;
+		this.resizeBypassRefreshThreshold = options.resizeBypassRefreshThreshold;
+		this.scrollAnimationTime = options.scrollAnimationTime;
+		this.scrollDebounceTime = options.scrollDebounceTime;
+		this.scrollThrottlingTime = options.scrollThrottlingTime;
+		this.scrollbarHeight = options.scrollbarHeight;
+		this.scrollbarWidth = options.scrollbarWidth;
 		this.stripedTable = options.stripedTable;
 
 		this.horizontal = false;
@@ -662,22 +663,22 @@ export class VirtualScrollerComponent implements OnInit, OnChanges, OnDestroy {
 	protected _marginDir;
 	protected updateDirection(): void {
 		if (this.horizontal) {
+			this._childScrollDim = 'childWidth';
 			this._invisiblePaddingProperty = 'width';
+			this._marginDir = 'margin-left';
 			this._offsetType = 'offsetLeft';
 			this._pageOffsetType = 'pageXOffset';
-			this._childScrollDim = 'childWidth';
-			this._marginDir = 'margin-left';
-			this._translateDir = 'translateX';
 			this._scrollType = 'scrollLeft';
+			this._translateDir = 'translateX';
 		}
 		else {
+			this._childScrollDim = 'childHeight';
 			this._invisiblePaddingProperty = 'height';
+			this._marginDir = 'margin-top';
 			this._offsetType = 'offsetTop';
 			this._pageOffsetType = 'pageYOffset';
-			this._childScrollDim = 'childHeight';
-			this._marginDir = 'margin-top';
-			this._translateDir = 'translateY';
 			this._scrollType = 'scrollTop';
+			this._translateDir = 'translateY';
 		}
 	}
 
@@ -740,7 +741,7 @@ export class VirtualScrollerComponent implements OnInit, OnChanges, OnDestroy {
 		//The default of 2x max will probably be accurate enough without causing too large a performance bottleneck
 		//The code would typically quit out on the 2nd iteration anyways. The main time it'd think more than 2 runs would be necessary would be for vastly different sized child items or if this is the 1st time the items array was initialized.
 		//Without maxRunTimes, If the user is actively scrolling this code would become an infinite loop until they stopped scrolling. This would be okay, except each scroll event would start an additional infinte loop. We want to short-circuit it to prevent this.
-		
+
 		if (itemsArrayModified && this.previousViewPort && this.previousViewPort.scrollStartPosition > 0) {
 		//if items were prepended, scroll forward to keep same items visible
 			let oldViewPort = this.previousViewPort;
@@ -1187,16 +1188,16 @@ export class VirtualScrollerComponent implements OnInit, OnChanges, OnDestroy {
 		let maxScrollPosition = Math.max(scrollLength - viewportLength, 0);
 
 		return {
-			itemCount: itemCount,
-			itemsPerWrapGroup: itemsPerWrapGroup,
-			wrapGroupsPerPage: wrapGroupsPerPage,
-			itemsPerPage: itemsPerPage,
-			pageCount_fractional: pageCount_fractional,
-			childWidth: defaultChildWidth,
 			childHeight: defaultChildHeight,
+			childWidth: defaultChildWidth,
+			itemCount: itemCount,
+			itemsPerPage: itemsPerPage,
+			itemsPerWrapGroup: itemsPerWrapGroup,
+			maxScrollPosition: maxScrollPosition,
+			pageCount_fractional: pageCount_fractional,
 			scrollLength: scrollLength,
 			viewportLength: viewportLength,
-			maxScrollPosition: maxScrollPosition
+			wrapGroupsPerPage: wrapGroupsPerPage,
 		};
 	}
 

--- a/src/virtual-scroller.ts
+++ b/src/virtual-scroller.ts
@@ -544,7 +544,7 @@ export class VirtualScrollerComponent implements OnInit, OnChanges, OnDestroy {
 			this.currentTween = undefined;
 		}
 
-		if (animationMilliseconds === 0) {
+		if (!animationMilliseconds) { // handles the `animationMilliseconds === 0` case
 			this.renderer.setProperty(scrollElement, this._scrollType, scrollPosition);
 			this.refresh_internal(false, animationCompletedCallback);
 			return;


### PR DESCRIPTION
I thought there was a bug in #420 but perhaps there wasn't:
- for clarity I changed the `!var` to `var === 0` because as far as I can tell is the only scenario that can happen there 😅 

Besides that:
- I've alphabetized certain sections for ease of reference
- I added indentation where appropriate
- I removed `InjectionToken` as it is not getting used anywhere in the code 🤔 

Biggest change is that `README.md` has been massively updated:
- Cleaner layout for the API table
    - sorted alphabetically
    - moved default value to `Type` column (for clarity)
    - moved long functions into descriptions (to keep middle column thinner and more-readable)
- emphasize key words for reading ease
- break up large paragraphs into meaningful sections
- show some `<text>` that got hidden because markdown hides things that are surrounded by `<` `>`
- switched tabs to spaces (else indentation is rendered with too much white space)
- etc

I was careful when editing the code, but please confirm I broke nothing just in case  😅 

I'm happy to undo / update / change my code as recommended 🤝 

Perhaps it would be better to undo the changes to all the code and simply make this PR about _Readme_ 🤷‍♂ 